### PR TITLE
feat: allow to use a non-root S3 bucket location

### DIFF
--- a/README.docker.md
+++ b/README.docker.md
@@ -167,9 +167,10 @@ This is controlled by the following configuration :
 * `REGISTRY_STORAGE_TIMEOUT`: Timeout (in milli-seconds) to use when interacting with the storage, defaults to 3000
 * `REGISTRY_S3_URI`: Endpoint base URI for the S3 service.
 * `REGISTRY_S3_REGION`: Sub-domain for the region.
-* `REGISTRY_S3_ACCESS_KEY`: The access key to use
-* `REGISTRY_S3_SECRET_KEY`: The secret key to use
+* `REGISTRY_S3_ACCESS_KEY`: The access key to use, set to empty string to search for existing credentials.
+* `REGISTRY_S3_SECRET_KEY`: The secret key to use, set to empty string to search for existing credentials.
 * `REGISTRY_S3_BUCKET`: The S3 bucket to use for storage. It will be created if it does not exist.
+* `REGISTRY_S3_ROOT`: The prefix to use for storing the data in the bucket (e.g. `/cratery/`), if not set or set to empty string, data will be stored in the root of the bucket.
 
 ### Index
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ This is controlled by the following configuration :
 * `REGISTRY_STORAGE_TIMEOUT`: Timeout (in milli-seconds) to use when interacting with the storage, defaults to 3000
 * `REGISTRY_S3_URI`: Endpoint base URI for the S3 service.
 * `REGISTRY_S3_REGION`: Sub-domain for the region.
-* `REGISTRY_S3_ACCESS_KEY`: The access key to use
-* `REGISTRY_S3_SECRET_KEY`: The secret key to use
+* `REGISTRY_S3_ACCESS_KEY`: The access key to use, set to empty string to search for existing credentials.
+* `REGISTRY_S3_SECRET_KEY`: The secret key to use, set to empty string to search for existing credentials.
 * `REGISTRY_S3_BUCKET`: The S3 bucket to use for storage. It will be created if it does not exist.
+* `REGISTRY_S3_ROOT`: The prefix to use for storing the data in the bucket (e.g. `/cratery/`), if not set or set to empty string, data will be stored in the root of the bucket.
 
 ### Index
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       # REGISTRY_S3_ACCESS_KEY:
       # REGISTRY_S3_SECRET_KEY:
       # REGISTRY_S3_BUCKET:
+      # REGISTRY_S3_ROOT:
       REGISTRY_OAUTH_LOGIN_URI: https://accounts.google.com/o/oauth2/v2/auth
       REGISTRY_OAUTH_TOKEN_URI: https://oauth2.googleapis.com/token
       REGISTRY_OAUTH_CALLBACK_URI: http://localhost/webapp/oauthcallback.html

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -110,6 +110,7 @@ impl StorageConfig {
                     region: get_var("REGISTRY_S3_REGION")?,
                     access_key: get_var("REGISTRY_S3_ACCESS_KEY")?,
                     secret_key: get_var("REGISTRY_S3_SECRET_KEY")?,
+                    root: get_var("REGISTRY_S3_ROOT").unwrap_or_default(),
                 },
                 bucket: get_var("REGISTRY_S3_BUCKET")?,
             },
@@ -132,6 +133,8 @@ pub struct S3Params {
     /// The account secret key
     #[serde(rename = "secretKey")]
     pub secret_key: String,
+    /// The prefix to use for the keys
+    pub root: String,
 }
 
 /// The configuration in the index

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -67,6 +67,7 @@ impl From<&Configuration> for StorageImpl {
             StorageConfig::S3 { params, bucket } => {
                 let builder = opendal::services::S3::default()
                     .bucket(bucket)
+                    .root(&params.root)
                     .region(&params.region)
                     .endpoint(&params.endpoint)
                     .access_key_id(&params.access_key)


### PR DESCRIPTION
This allows to direct cratery to use a 'subdirectory' to store its data on S3.  This is useful to not have to dedicate a bucket to cratery (which may or may not be appropriate). E.g. instead of using `my-cratery-bucket/` we can now use `my-multipurpose-bucket/cratery/`.