### PR TITLE
chore: update help text to use credentials.toml

### DIFF
--- a/src/webapp/account.html
+++ b/src/webapp/account.html
@@ -128,7 +128,7 @@
               </p>
               <textarea id="modal-token-created-git-cred" rows="2" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" style="font-family: monospace;" disabled></textarea>
               <p class="text-base text-gray-900 dark:text-white">
-                It also needs to appear in <kbd>~/.cargo/credentials</kbd>:
+                It also needs to appear in <kbd>~/.cargo/credentials.toml</kbd>:
               </p>
               <textarea id="modal-token-created-cargo-cred" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" style="font-family: monospace;" disabled></textarea>
               <p class="text-base text-gray-900 dark:text-white">

--- a/src/webapp/admin-tokens.html
+++ b/src/webapp/admin-tokens.html
@@ -102,7 +102,7 @@
               </p>
               <textarea id="modal-token-created-git-cred" rows="2" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" style="font-family: monospace;" disabled></textarea>
               <p class="text-base text-gray-900 dark:text-white">
-                It also needs to appear in <kbd>~/.cargo/credentials</kbd>:
+                It also needs to appear in <kbd>~/.cargo/credentials.toml</kbd>:
               </p>
               <textarea id="modal-token-created-cargo-cred" rows="4" class="block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" style="font-family: monospace;" disabled></textarea>
               <p class="text-base text-gray-900 dark:text-white">


### PR DESCRIPTION
When creating new tokens, we get a helpful message that tells us how to configure everything so that the token (and registry) is picked up correctly.  However it suggests to use `.cargo/credentials`, which will result in a deprecation warning from cargo that `.cargo/credentials.toml` is preferred.