### PR TITLE
Use explicit request for json return data during OAuth token request.

### DIFF
--- a/src/services/database/users.rs
+++ b/src/services/database/users.rs
@@ -48,6 +48,7 @@ impl Database {
                 ("client_id", &configuration.oauth_client_id),
                 ("client_secret", &configuration.oauth_client_secret),
             ])
+            .header(reqwest::header::ACCEPT, "application/json")
             .send()
             .await?;
         if !response.status().is_success() {


### PR DESCRIPTION
Some OAuth providers like GitHub default to return web encoded strings instead of JSON. This enables the use of cratery with GitHub Enterprise as OAuth provider.