### PR TITLE
Faster ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       with:
           log-level: warn
           command: check
+    - uses: Swatinem/rust-cache@v2
     - name: Check fmt
       run: cargo fmt --check
     - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Check fmt
       run: cargo fmt --check
     - name: Lint
-      run: cargo clippy
+      run: cargo clippy --locked
     - name: Run tests
-      run: cargo test
+      run: cargo test --locked


### PR DESCRIPTION
Add rust-cache step + `--locked` option for `cargo clippy` and `cargo test` steps

use tips from blog post : [Tips for Faster Rust CI Builds](https://corrode.dev/blog/tips-for-faster-ci-builds/#use-swatinem-s-cache-action)