### PR TITLE
add spelling check with typos in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Check fmt
       run: cargo fmt --check
+    - name: Check spelling
+      uses: crate-ci/typos@master
     - name: Lint
       run: cargo clippy --locked
     - name: Run tests


### PR DESCRIPTION
doc can be found here :
https://github.com/crate-ci/typos/blob/master/docs/github-action.md

This can permit to find typos errors before merge code in master, and limit the need of 'fix commits'.