### PR TITLE
style(clippy): replace an use of `map_or` by more approriated `is_some_and`

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -965,7 +965,7 @@ pub async fn index_serve_inner(
     let stream = ReaderStream::new(file);
     if std::path::Path::new(path)
         .extension()
-        .map_or(false, |ext| ext.eq_ignore_ascii_case("json"))
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
     {
         Ok((stream, HeaderValue::from_static("application/json")))
     } else if path == "/HEAD" || path.starts_with("/info") {


### PR DESCRIPTION
clippy warning: this `map_or` is redundant
help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or clippy::unnecessary_map_or