### PR TITLE
feat: allow to retry temporary storage failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ This is controlled by the following configuration :
 * `REGISTRY_S3_SECRET_KEY`: The secret key to use, set to empty string to search for existing credentials.
 * `REGISTRY_S3_BUCKET`: The S3 bucket to use for storage. It will be created if it does not exist.
 * `REGISTRY_S3_ROOT`: The prefix to use for storing the data in the bucket (e.g. `/cratery/`), if not set or set to empty string, data will be stored in the root of the bucket.
+* `REGISTRY_STORAGE_RETRY_ENABLED`: Whether to retry temporary errors when accessing the storage, defaults to `false`, enable with `true` or `1`.  Retrying can be used for `S3` and `fs` storage.  If enabled, the following parameters can be used to further configure the retry behaviour:
+    * `REGISTRY_STORAGE_RETRY_MAX_TIMES`: Maximum number of retries to perform, defaults to `3`.
+    * `REGISTRY_STORAGE_RETRY_MIN_DELAY_MS`: Minimum delay (in milliseconds) between retries, defaults to `1000`.
+    * `REGISTRY_STORAGE_RETRY_MAX_DELAY_MS`: Maximum delay (in milliseconds) between retries, defaults to `60000`.
+    * `REGISTRY_STORAGE_RETRY_MAX_FACTOR`: Factor to use to increase the delay between retries, defaults to `2.0`.
+    * `REGISTRY_STORAGE_RETRY_JITTER`: Whether to add a random jitter to the delay between retries, defaults to `false`, enable with `true` or `1`.
 
 ### Index
 


### PR DESCRIPTION
Use a `RetryLayer` to make OpenDAL retry operations that aren't permanent errors.  This can for example happen with S3 interactions where the API returns a temporary error but the operation would succeed if retried.  Doing the retry as part of the storage layer reduces the chances of temporary failures to cause user-visible errors.

The configuration allows to use the retry-mechanism on file-system level storage as well, though likely less applicable there.

Note that only temporary errors are retried, following the OpenDAL classification of error classes, so operations that just will not succeed are not retried needlessly and an error is returned immediately.