### PR TITLE
style: update Cargo.toml formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bytes = "1.7"
 chrono = { version = "0.4.38", features = ["serde"] }
 cookie = { version = "0.18", features = ["secure", "percent-encode"] }
 data-encoding = "2.1"
-flate2 ="1.0"
+flate2 = "1.0"
 http-body = "1"
 mime = "0.3"
 opendal = { version = "0.53", features = ["services-fs", "services-s3"] }
@@ -36,17 +36,32 @@ ring = "0.17"
 semver = { version = "1.0", features = ["serde"] }
 urlencoding = "2.1"
 tar = "0.4.41"
-uuid =  { version = "1.2", features = ["v4", "fast-rng"] }
+uuid = { version = "1.2", features = ["v4", "fast-rng"] }
 
 # async support
 futures = "0.3"
 tokio = { version = "1.38", features = ["full"] }
 tokio-stream = "0.1.15"
-tokio-util = {version = "0.7", features = ["io"]}
+tokio-util = { version = "0.7", features = ["io"] }
 
 # framework for the application
-lettre = { version = "0.11", default-features = false, features = ["builder", "smtp-transport", "rustls-tls", "tokio1", "tokio1-rustls-tls"] }
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite", "macros", "chrono"] }
+lettre = { version = "0.11", default-features = false, features = [
+    "builder",
+    "smtp-transport",
+    "rustls-tls",
+    "tokio1",
+    "tokio1-rustls-tls",
+] }
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio-rustls",
+    "sqlite",
+    "macros",
+    "chrono",
+] }
 axum = { version = "0.8", features = ["http2", "ws"] }
-reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "stream",
+    "rustls-tls",
+    "rustls-tls-native-roots",
+] }
 tokio-tungstenite = "0.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ quick-xml = "0.37"
 rand = "0.8"
 ring = "0.17"
 semver = { version = "1.0", features = ["serde"] }
-urlencoding = "2.1"
 tar = "0.4.41"
+urlencoding = "2.1"
 uuid = { version = "1.2", features = ["v4", "fast-rng"] }
 
 # async support


### PR DESCRIPTION
fixes for consistency and splitting some values across multiple lines for readability.

Auto-formatting was done with `Even Better TOML` Vscode extension.

Note: ideally this should be checked by CI, but there is no Github action available for now.
I have started a PR to create one : https://github.com/tamasfe/taplo/pull/790
Possibly this could be done manually in the meantime. A working basis could be found in Issue https://github.com/tamasfe/taplo/issues/470