### PR TITLE
more fine-grained error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tar",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +450,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "smol_str",
  "sqlx",
  "tar",
  "thiserror 2.0.17",
@@ -2430,6 +2440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f7a918bd2a9951d18ee6e48f076843e8e73a9a5d22cf05bcd4b7a81bdd04e17"
+dependencies = [
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "flate2",
  "futures",
  "http-body",
+ "http-serde",
  "lettre",
  "log",
  "opendal",
@@ -442,7 +443,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tar",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -1023,6 +1024,16 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
 name = "cratery"
 version = "1.13.0"
 dependencies = [
+ "anyhow",
  "axum",
  "base64",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tar",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.28.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "flate2",
  "futures",
  "http-body",
+ "http-serde",
  "lettre",
  "log",
  "opendal",
@@ -1113,6 +1114,16 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -234,6 +234,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -449,6 +459,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "smol_str",
  "sqlx",
  "tar",
  "thiserror",
@@ -2734,6 +2745,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
 name = "cratery"
 version = "1.13.0"
 dependencies = [
+ "anyhow",
  "axum",
  "base64 0.22.1",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rand = "0.9"
 ring = "0.17"
 semver = { version = "1.0", features = ["serde"] }
 tar = "0.4"
+thiserror = "2.0"
 urlencoding = "2.1"
 uuid = { version = "1.19", features = ["fast-rng", "v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ opendal = { version = "0.55", features = ["services-fs", "services-s3"] }
 rand = "0.9"
 ring = "0.17"
 semver = { version = "1.0", features = ["serde"] }
+smol_str = "0.3"
 tar = "0.4"
 thiserror = "2.0"
 urlencoding = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cookie = { version = "0.18", features = ["percent-encode", "secure"] }
 data-encoding = "2.10"
 flate2 = "1.1"
 http-body = "1"
+http-serde = "2.1"
 opendal = { version = "0.55", features = ["services-fs", "services-s3"] }
 rand = "0.9"
 ring = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 # basic dependencies
+anyhow = "1.0"
 base64 = "0.22"
 byteorder = "1.5"
 bytes = "1.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ opendal = { version = "0.58", features = ["services-fs", "services-s3"] }
 rand = "0.9"
 ring = "0.17"
 semver = { version = "1.0", features = ["serde"] }
+smol_str = "0.3"
 tar = "0.4"
 thiserror = "2.0"
 urlencoding = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cookie = { version = "0.18", features = ["percent-encode", "secure"] }
 data-encoding = "2.10"
 flate2 = "1.1"
 http-body = "1"
+http-serde = "2.1"
 opendal = { version = "0.58", features = ["services-fs", "services-s3"] }
 rand = "0.9"
 ring = "0.17"

--- a/src/application.rs
+++ b/src/application.rs
@@ -290,7 +290,7 @@ impl Application {
     pub async fn get_current_user(&self, auth_data: &AuthData) -> Result<RegistryUser, ApiError> {
         self.db_transaction_read(|app| async move {
             let authentication = app.authenticate(auth_data).await?;
-            app.database.get_user_profile(authentication.uid()?).await
+            app.database.get_user_profile(authentication.uid()?).await.map_err(Into::into)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -435,7 +435,7 @@ impl Application {
         self.db_transaction_read(|app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_admin_registry(&authentication).await?;
-            app.database.get_global_tokens().await
+            app.database.get_global_tokens().await.map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -794,7 +794,10 @@ impl Application {
     pub async fn get_crate_required_capabilities(&self, auth_data: &AuthData, package: &str) -> Result<Vec<String>, ApiError> {
         self.db_transaction_read(|app| async move {
             let _authentication = app.authenticate(auth_data).await?;
-            app.database.get_crate_required_capabilities(package).await
+            app.database
+                .get_crate_required_capabilities(package)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -821,7 +824,10 @@ impl Application {
         self.db_transaction_write("set_crate_deprecation", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_manage_crate(&authentication, package).await?;
-            app.database.set_crate_deprecation(package, deprecated).await
+            app.database
+                .set_crate_deprecation(package, deprecated)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -831,7 +837,10 @@ impl Application {
         self.db_transaction_write("set_crate_can_remove", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_manage_crate(&authentication, package).await?;
-            app.database.set_crate_can_remove(package, can_remove).await
+            app.database
+                .set_crate_can_remove(package, can_remove)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -354,7 +354,10 @@ impl Application {
                 app.check_can_admin_registry(&authentication).await?;
                 true
             };
-            app.database.update_user(principal_uid, target, can_admin).await
+            app.database
+                .update_user(principal_uid, target, can_admin)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -526,6 +526,7 @@ impl Application {
                 app.database
                     .get_crate_info(package, self.service_index.get_crate_data(package).await?)
                     .await
+                    .map_err(ApiError::from)
             })
             .await?;
         let metadata = self
@@ -598,7 +599,10 @@ impl Application {
         self.db_transaction_write("yank_crate_version", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_manage_crate(&authentication, package).await?;
-            app.database.yank_crate_version(package, version).await
+            app.database
+                .yank_crate_version(package, version)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -613,7 +617,10 @@ impl Application {
         self.db_transaction_write("unyank_crate_version", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_manage_crate(&authentication, package).await?;
-            app.database.unyank_crate_version(package, version).await
+            app.database
+                .unyank_crate_version(package, version)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -695,7 +702,7 @@ impl Application {
     pub async fn get_crates_outdated_heads(&self, auth_data: &AuthData) -> Result<Vec<CrateVersion>, ApiError> {
         self.db_transaction_read(|app| async move {
             let _authentication = app.authenticate(auth_data).await?;
-            app.database.get_crates_outdated_heads().await
+            app.database.get_crates_outdated_heads().await.map_err(ApiError::from)
         })
         .await
     }
@@ -704,7 +711,7 @@ impl Application {
     pub async fn get_crate_dl_stats(&self, auth_data: &AuthData, package: &str) -> Result<DownloadStats, ApiError> {
         self.db_transaction_read(|app| async move {
             let _authentication = app.authenticate(auth_data).await?;
-            app.database.get_crate_dl_stats(package).await
+            app.database.get_crate_dl_stats(package).await.map_err(ApiError::from)
         })
         .await
     }
@@ -716,7 +723,7 @@ impl Application {
             if !public_read {
                 let _authentication = app.authenticate(auth_data).await?;
             }
-            app.database.get_crate_owners(package).await
+            app.database.get_crate_owners(package).await.map_err(ApiError::from)
         })
         .await
     }
@@ -731,7 +738,10 @@ impl Application {
         self.db_transaction_write("add_crate_owners", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_manage_crate(&authentication, package).await?;
-            app.database.add_crate_owners(package, new_users).await
+            app.database
+                .add_crate_owners(package, new_users)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -746,7 +756,10 @@ impl Application {
         self.db_transaction_write("remove_crate_owners", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_manage_crate(&authentication, package).await?;
-            app.database.remove_crate_owners(package, old_users).await
+            app.database
+                .remove_crate_owners(package, old_users)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -755,7 +768,7 @@ impl Application {
     pub async fn get_crate_targets(&self, auth_data: &AuthData, package: &str) -> Result<Vec<CrateInfoTarget>, ApiError> {
         self.db_transaction_read(|app| async move {
             let _authentication = app.authenticate(auth_data).await?;
-            app.database.get_crate_targets(package).await
+            app.database.get_crate_targets(package).await.map_err(ApiError::from)
         })
         .await
     }
@@ -874,7 +887,10 @@ impl Application {
             if !public_read {
                 let _authentication = app.authenticate(auth_data).await?;
             }
-            app.database.search_crates(query, per_page, deprecated).await
+            app.database
+                .search_crates(query, per_page, deprecated)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -890,7 +906,7 @@ impl Application {
             .db_transaction_read(|app| async move {
                 let _authentication = app.authenticate(auth_data).await?;
                 app.database.check_crate_exists(package, version).await?;
-                app.database.get_crate_targets(package).await
+                app.database.get_crate_targets(package).await.map_err(ApiError::from)
             })
             .await?;
         let targets = targets.into_iter().map(|info| info.target).collect::<Vec<_>>();

--- a/src/application.rs
+++ b/src/application.rs
@@ -439,7 +439,7 @@ impl Application {
         self.db_transaction_write("create_global_token", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_admin_registry(&authentication).await?;
-            app.database.create_global_token(name).await
+            app.database.create_global_token(name).await.map_err(ApiError::from)
         })
         .await
     }
@@ -449,7 +449,7 @@ impl Application {
         self.db_transaction_write("revoke_global_token", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_admin_registry(&authentication).await?;
-            app.database.revoke_global_token(token_id).await
+            app.database.revoke_global_token(token_id).await.map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -323,7 +323,10 @@ impl Application {
     /// Attempts to login using an OAuth code
     pub async fn login_with_oauth_code(&self, code: &str) -> Result<RegistryUser, ApiError> {
         self.db_transaction_write("login_with_oauth_code", |app| async move {
-            app.database.login_with_oauth_code(&self.configuration, code).await
+            app.database
+                .login_with_oauth_code(&self.configuration, code)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -890,6 +890,9 @@ pub enum AuthenticationError {
     #[error("user is not authenticated.")]
     Unauthorized,
 
+    #[error("access is forbidden for user")]
+    Forbidden,
+
     #[error("failed to check global token")]
     GlobalToken(#[source] sqlx::Error),
 
@@ -899,6 +902,9 @@ pub enum AuthenticationError {
     #[error("failed to check user token")]
     CheckUser(#[source] sqlx::Error),
 
+    #[error("failed to check user roles")]
+    CheckRoles(#[source] sqlx::Error),
+
     #[error("expected a user to be authenticated")]
     NoUserAuthenticated,
 }
@@ -907,10 +913,13 @@ impl AsStatusCode for AuthenticationError {
     fn status_code(&self) -> StatusCode {
         match self {
             Self::Unauthorized | Self::CookieMissing => StatusCode::UNAUTHORIZED,
-            Self::CookieDeserialization(_) | Self::GlobalToken(_) | Self::UserToken(_) | Self::CheckUser(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            Self::CookieDeserialization(_)
+            | Self::GlobalToken(_)
+            | Self::UserToken(_)
+            | Self::CheckUser(_)
+            | Self::CheckRoles(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::NoUserAuthenticated => StatusCode::BAD_REQUEST,
+            Self::Forbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -869,7 +869,7 @@ impl Application {
     pub async fn get_crates_stats(&self, auth_data: &AuthData) -> Result<GlobalStats, ApiError> {
         self.db_transaction_read(|app| async move {
             let _authentication = app.authenticate(auth_data).await?;
-            app.database.get_crates_stats().await
+            app.database.get_crates_stats().await.map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -336,7 +336,7 @@ impl Application {
         self.db_transaction_read(|app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_admin_registry(&authentication).await?;
-            app.database.get_users().await
+            app.database.get_users().await.map_err(ApiError::from)
         })
         .await
     }
@@ -377,7 +377,7 @@ impl Application {
         self.db_transaction_write("reactivate_user", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_admin_registry(&authentication).await?;
-            app.database.reactivate_user(target).await
+            app.database.reactivate_user(target).await.map_err(ApiError::from)
         })
         .await
     }
@@ -397,7 +397,7 @@ impl Application {
         self.db_transaction_read(|app| async move {
             let authentication = app.authenticate(auth_data).await?;
             authentication.check_can_admin()?;
-            app.database.get_tokens(authentication.uid()?).await
+            app.database.get_tokens(authentication.uid()?).await.map_err(ApiError::from)
         })
         .await
     }
@@ -416,6 +416,7 @@ impl Application {
             app.database
                 .create_token(authentication.uid()?, name, can_write, can_admin)
                 .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -425,7 +426,10 @@ impl Application {
         self.db_transaction_write("revoke_token", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             authentication.check_can_admin()?;
-            app.database.revoke_token(authentication.uid()?, token_id).await
+            app.database
+                .revoke_token(authentication.uid()?, token_id)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -896,6 +896,9 @@ pub enum AuthenticationError {
     #[error("administration is forbidden for this authentication")]
     AdministrationIsForbidden,
 
+    #[error("writing is forbidden for this authentication")]
+    WriteIsForbidden,
+
     #[error("failed to check global token")]
     GlobalToken(#[source] sqlx::Error),
 
@@ -922,7 +925,7 @@ impl AsStatusCode for AuthenticationError {
             | Self::CheckUser(_)
             | Self::CheckRoles(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::NoUserAuthenticated => StatusCode::BAD_REQUEST,
-            Self::Forbidden | Self::AdministrationIsForbidden => StatusCode::FORBIDDEN,
+            Self::Forbidden | Self::AdministrationIsForbidden | Self::WriteIsForbidden => StatusCode::FORBIDDEN,
         }
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -33,7 +33,7 @@ use crate::services::emails::EmailSender;
 use crate::services::index::Index;
 use crate::services::rustsec::RustSecChecker;
 use crate::services::storage::Storage;
-use crate::utils::apierror::{ApiError, AsStatusCode, error_forbidden, error_invalid_request, error_unauthorized, specialize};
+use crate::utils::apierror::{ApiError, AsStatusCode, error_forbidden, error_invalid_request, specialize};
 use crate::utils::axum::auth::{AuthData, Token};
 use crate::utils::db::RwSqlitePool;
 
@@ -876,6 +876,42 @@ impl Application {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum AuthenticationError {
+    #[error("missing cookie")]
+    CookieMissing,
+
+    #[error("failed to deserialize cookie")]
+    CookieDeserialization(serde_json::Error),
+
+    #[error("user is not authenticated.")]
+    Unauthorized,
+
+    #[error("failed to check global token")]
+    GlobalToken(#[source] sqlx::Error),
+
+    #[error("failed to check user token")]
+    UserToken(#[source] sqlx::Error),
+
+    #[error("failed to check user token")]
+    CheckUser(#[source] sqlx::Error),
+
+    #[error("expected a user to be authenticated")]
+    NoUserAuthenticated,
+}
+
+impl AsStatusCode for AuthenticationError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::Unauthorized | Self::CookieMissing => StatusCode::UNAUTHORIZED,
+            Self::CookieDeserialization(_) | Self::GlobalToken(_) | Self::UserToken(_) | Self::CheckUser(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Self::NoUserAuthenticated => StatusCode::BAD_REQUEST,
+        }
+    }
+}
+
 /// The application, running with a transaction
 pub(crate) struct ApplicationWithTransaction<'a> {
     /// The application with its services
@@ -888,16 +924,20 @@ impl ApplicationWithTransaction<'_> {
     /// Attempts the authentication of a user
     async fn authenticate(&self, auth_data: &AuthData) -> Result<Authentication, ApiError> {
         if let Some(token) = &auth_data.token {
-            self.authenticate_token(token).await
+            self.authenticate_token(token).await.map_err(ApiError::from)
         } else {
-            let authentication = auth_data.try_authenticate_cookie()?.ok_or_else(error_unauthorized)?;
-            self.database.check_is_user(authentication.email()?).await?;
+            let authentication = auth_data
+                .try_authenticate_cookie()
+                .map_err(AuthenticationError::CookieDeserialization)?
+                .ok_or_else(|| AuthenticationError::CookieMissing)?;
+            let email = authentication.email().map_err(ApiError::from)?;
+            self.database.check_is_user(email).await?;
             Ok(authentication)
         }
     }
 
     /// Tries to authenticate using a token
-    async fn authenticate_token(&self, token: &Token) -> Result<Authentication, ApiError> {
+    async fn authenticate_token(&self, token: &Token) -> Result<Authentication, AuthenticationError> {
         if token.id == self.application.configuration.self_service_login
             && token.secret == self.application.configuration.self_service_token
         {

--- a/src/application.rs
+++ b/src/application.rs
@@ -367,7 +367,10 @@ impl Application {
         self.db_transaction_write("deactivate_user", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             let principal_uid = app.check_can_admin_registry(&authentication).await?;
-            app.database.deactivate_user(principal_uid, target).await
+            app.database
+                .deactivate_user(principal_uid, target)
+                .await
+                .map_err(ApiError::from)
         })
         .await
     }
@@ -387,7 +390,7 @@ impl Application {
         self.db_transaction_write("delete_user", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             let principal_uid = app.check_can_admin_registry(&authentication).await?;
-            app.database.delete_user(principal_uid, target).await
+            app.database.delete_user(principal_uid, target).await.map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -8,7 +8,9 @@ use std::future::Future;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use axum::http::StatusCode;
 use log::{error, info};
+use thiserror::Error;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 
 use crate::model::auth::{Authentication, RegistryUserToken, RegistryUserTokenWithSecret};
@@ -23,6 +25,7 @@ use crate::model::stats::{DownloadStats, GlobalStats};
 use crate::model::worker::{WorkerEvent, WorkerPublicData, WorkersManager};
 use crate::model::{AppEvent, CrateVersion, RegistryInformation};
 use crate::services::ServiceProvider;
+use crate::services::database::packages::DepsError;
 use crate::services::database::{Database, db_transaction_read, db_transaction_write};
 use crate::services::deps::DepsChecker;
 use crate::services::docs::DocsGenerator;
@@ -30,7 +33,7 @@ use crate::services::emails::EmailSender;
 use crate::services::index::Index;
 use crate::services::rustsec::RustSecChecker;
 use crate::services::storage::Storage;
-use crate::utils::apierror::{ApiError, error_forbidden, error_invalid_request, error_unauthorized, specialize};
+use crate::utils::apierror::{ApiError, AsStatusCode, error_forbidden, error_invalid_request, error_unauthorized, specialize};
 use crate::utils::axum::auth::{AuthData, Token};
 use crate::utils::db::RwSqlitePool;
 
@@ -186,14 +189,36 @@ impl Application {
 
     /// Handles a set of events
     async fn events_handler_handle(&self, events: &[AppEvent]) -> Result<(), ApiError> {
+        #[derive(Debug, Error)]
+        enum EventHandlerError {
+            #[error("failed to update token last usage")]
+            UpdateTokenUsage(#[source] sqlx::Error),
+            #[error("failed to increment crate version download count")]
+            CrateDownload(#[source] DepsError),
+        }
+        impl AsStatusCode for EventHandlerError {
+            fn status_code(&self) -> StatusCode {
+                match self {
+                    Self::UpdateTokenUsage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                    Self::CrateDownload(deps_error) => deps_error.status_code(),
+                }
+            }
+        }
+
         self.db_transaction_write("events_handler_handle", |app| async move {
             for event in events {
                 match event {
                     AppEvent::TokenUse(usage) => {
-                        app.database.update_token_last_usage(usage).await?;
+                        app.database
+                            .update_token_last_usage(usage)
+                            .await
+                            .map_err(EventHandlerError::UpdateTokenUsage)?;
                     }
                     AppEvent::CrateDownload(CrateVersion { package: name, version }) => {
-                        app.database.increment_crate_version_dl_count(name, version).await?;
+                        app.database
+                            .increment_crate_version_dl_count(name, version)
+                            .await
+                            .map_err(EventHandlerError::CrateDownload)?;
                     }
                 }
             }
@@ -587,6 +612,7 @@ impl Application {
             app.database
                 .get_undocumented_crates(&self.configuration.self_toolchain_host)
                 .await
+                .map_err(ApiError::from)
         })
         .await
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -222,18 +222,15 @@ impl Application {
             if count == 0 {
                 break;
             }
-            if let Err(e) = self.events_handler_handle(&events).await {
-                error!("{e}");
-                if let Some(backtrace) = e.backtrace {
-                    error!("{backtrace}");
-                }
+            if let Err(err) = self.events_handler_handle(&events).await {
+                error!("events_handler - {:#?}", anyhow::Error::from(err));
             }
             events.clear();
         }
     }
 
     /// Handles a set of events
-    async fn events_handler_handle(&self, events: &[AppEvent]) -> Result<(), ApiError> {
+    async fn events_handler_handle(&self, events: &[AppEvent]) -> Result<(), DbWriteError> {
         #[derive(Debug, Error)]
         enum EventHandlerError {
             #[error("failed to update token last usage")]
@@ -270,7 +267,6 @@ impl Application {
             Ok::<_, EventHandlerError>(())
         })
         .await
-        .map_err(ApiError::from)
     }
 
     /// Executes a piece of work in the context of a transaction

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn setup_log() {
 
 /// Main entry point
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     setup_log();
     info!("{CRATE_NAME} commit={GIT_HASH} tag={GIT_TAG}");
     let configuration = services::StandardServiceProvider::get_configuration().await.unwrap();
@@ -205,4 +205,5 @@ async fn main() {
         let server = pin!(main_serve_app(application, cookie_key,));
         let _ = waiting_sigterm(server).await;
     }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ async fn main() -> anyhow::Result<()> {
         // standalone or master
         let application = Application::launch::<services::StandardServiceProvider>(configuration)
             .await
-            .unwrap();
+            .context("failed to launch application")?;
         let cookie_key = Key::from(
             std::env::var("REGISTRY_WEB_COOKIE_SECRET")
                 .expect("REGISTRY_WEB_COOKIE_SECRET must be set")

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,8 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("Failed to get configuration for Standard Service Provider.")?;
     if configuration.self_role.is_worker() {
-        let _ = waiting_sigterm(pin!(worker::main_worker(configuration))).await;
+        let worker = pin!(worker::main_worker(configuration));
+        waiting_sigterm(worker).await.context("an error terminate worker execution")?;
     } else {
         // standalone or master
         let application = Application::launch::<services::StandardServiceProvider>(configuration)
@@ -222,7 +223,7 @@ async fn main() -> anyhow::Result<()> {
                 .as_bytes(),
         );
         let server = pin!(main_serve_app(application, cookie_key,));
-        let _ = waiting_sigterm(server).await;
+        waiting_sigterm(server).await.context("an error terminate server execution")?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,9 @@ fn setup_log() -> Result<(), SetLoggerError> {
 async fn main() -> anyhow::Result<()> {
     setup_log().context("Failed to setup logger")?;
     info!("{CRATE_NAME} commit={GIT_HASH} tag={GIT_TAG}");
-    let configuration = services::StandardServiceProvider::get_configuration().await.unwrap();
+    let configuration = services::StandardServiceProvider::get_configuration()
+        .await
+        .context("Failed to get configuration for Standard Service Provider.")?;
     if configuration.self_role.is_worker() {
         let _ = waiting_sigterm(pin!(worker::main_worker(configuration))).await;
     } else {

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -9,7 +9,6 @@ use std::ops::DerefMut;
 use log::info;
 use sqlx::{Executor, SqliteConnection};
 
-use crate::utils::apierror::ApiError;
 use crate::utils::db::{AppTransaction, Migration, MigrationContent, MigrationError, SCHEMA_METADATA_VERSION, VersionNumber};
 
 /// The migrations
@@ -166,7 +165,7 @@ async fn migrate_db(transaction: AppTransaction, migrations: &[Migration<'_>]) -
 }
 
 /// Migrate to the last version
-pub async fn migrate_to_last(transaction: AppTransaction) -> Result<i32, ApiError> {
+pub async fn migrate_to_last(transaction: AppTransaction) -> Result<i32, MigrationError> {
     migrate_db(transaction, MIGRATIONS).await?;
     Ok(0)
 }

--- a/src/model/auth.rs
+++ b/src/model/auth.rs
@@ -7,7 +7,10 @@
 use chrono::NaiveDateTime;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::utils::apierror::{ApiError, error_forbidden, error_invalid_request, specialize};
+use crate::{
+    application::AuthenticationError,
+    utils::apierror::{ApiError, error_forbidden, specialize},
+};
 
 /// The admin role
 pub const ROLE_ADMIN: &str = "admin";
@@ -57,26 +60,20 @@ impl Authentication {
     }
 
     /// Gets the uid of the associated user
-    pub fn uid(&self) -> Result<i64, ApiError> {
+    pub const fn uid(&self) -> Result<i64, AuthenticationError> {
         if let AuthenticationPrincipal::User { uid, email: _ } = &self.principal {
             Ok(*uid)
         } else {
-            Err(specialize(
-                error_invalid_request(),
-                String::from("Expected a user to be authenticated"),
-            ))
+            Err(AuthenticationError::NoUserAuthenticated)
         }
     }
 
     /// Gets the email of the associated user
-    pub fn email(&self) -> Result<&str, ApiError> {
+    pub fn email(&self) -> Result<&str, AuthenticationError> {
         if let AuthenticationPrincipal::User { uid: _, email } = &self.principal {
             Ok(email)
         } else {
-            Err(specialize(
-                error_invalid_request(),
-                String::from("Expected a user to be authenticated"),
-            ))
+            Err(AuthenticationError::NoUserAuthenticated)
         }
     }
 

--- a/src/model/auth.rs
+++ b/src/model/auth.rs
@@ -7,10 +7,7 @@
 use chrono::NaiveDateTime;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::{
-    application::AuthenticationError,
-    utils::apierror::{ApiError, error_forbidden, specialize},
-};
+use crate::application::AuthenticationError;
 
 /// The admin role
 pub const ROLE_ADMIN: &str = "admin";
@@ -78,14 +75,11 @@ impl Authentication {
     }
 
     /// Checks that this authentication enables writing
-    pub fn check_can_write(&self) -> Result<(), ApiError> {
+    pub const fn check_can_write(&self) -> Result<(), AuthenticationError> {
         if self.can_write {
             Ok(())
         } else {
-            Err(specialize(
-                error_forbidden(),
-                String::from("writing is forbidden for this authentication"),
-            ))
+            Err(AuthenticationError::WriteIsForbidden)
         }
     }
 

--- a/src/model/auth.rs
+++ b/src/model/auth.rs
@@ -90,14 +90,11 @@ impl Authentication {
     }
 
     /// Checks that this authentication enables admin tasks
-    pub fn check_can_admin(&self) -> Result<(), ApiError> {
+    pub const fn check_can_admin(&self) -> Result<(), AuthenticationError> {
         if self.can_admin {
             Ok(())
         } else {
-            Err(specialize(
-                error_forbidden(),
-                String::from("administration is forbidden for this authentication"),
-            ))
+            Err(AuthenticationError::AdministrationIsForbidden)
         }
     }
 }

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -15,7 +15,7 @@ use base64::engine::general_purpose::STANDARD;
 use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::fs::File;
-use tokio::io::{self, AsyncWriteExt, BufWriter};
+use tokio::io::{self, AsyncWrite, AsyncWriteExt, BufWriter};
 use tokio::process::Command;
 
 use super::{CHANNEL_NIGHTLY, CHANNEL_STABLE};
@@ -26,27 +26,25 @@ use crate::utils::token::generate_token;
 
 #[derive(Debug, Error)]
 pub enum WriteConfigError {
-    #[error("failed to write '{path}'")]
-    CreateConfigToml {
+    #[error("failed to create file '{path}'")]
+    CreateConfigFile {
         #[source]
         source: io::Error,
         path: PathBuf,
     },
 
-    #[error("failed to write config file content")]
-    WriteContent(#[from] io::Error),
+    #[error("failed to write file content")]
+    WriteContent(#[source] io::Error),
 }
 
 #[derive(Debug, Error)]
 pub enum WriteAuthConfigError {
-    #[error("failed to write config.toml")]
-    WriteConfig(#[source] WriteConfigError),
-
-    #[error("failed to write credential.toml")]
-    WriteCredentials(#[source] WriteConfigError),
-
-    #[error("hack to allow progressiv work")]
-    ApiError,
+    #[error("failed to write `{filename}`")]
+    WriteAuthConfig {
+        #[source]
+        source: WriteConfigError,
+        filename: &'static str,
+    },
 }
 impl AsStatusCode for WriteAuthConfigError {}
 
@@ -757,35 +755,64 @@ impl Configuration {
     /// Return an error when writing fail
     pub async fn write_auth_config(&self) -> Result<(), WriteAuthConfigError> {
         if self.index.allow_protocol_git {
-            self.write_auth_config_git_config()
-                .await
-                .map_err(|_| WriteAuthConfigError::ApiError)?;
-            self.write_auth_config_git_credentials()
-                .await
-                .map_err(|_| WriteAuthConfigError::ApiError)?;
+            self.write_auth_config_git_config().await?;
+            self.write_auth_config_git_credentials().await?;
         }
-        self.write_auth_config_cargo_config()
-            .await
-            .map_err(WriteAuthConfigError::WriteConfig)?;
-        self.write_auth_config_cargo_credentials()
-            .await
-            .map_err(WriteAuthConfigError::WriteCredentials)?;
+        self.write_auth_cargo_config().await?;
+        self.write_auth_config_cargo_credentials().await?;
         Ok(())
     }
 
+    async fn create_config_file(&self, path: &[&str]) -> Result<BufWriter<File>, WriteConfigError> {
+        let path = self.get_home_path_for(path);
+        let file = File::create(&path)
+            .await
+            .map_err(|source| WriteConfigError::CreateConfigFile { source, path })?;
+        Ok(BufWriter::new(file))
+    }
+
+    async fn write_auth_config_git_config(&self) -> Result<(), WriteAuthConfigError> {
+        const GIT_CONFIG_FILENAME: &str = ".gitconfig";
+        let mk_err = |source: WriteConfigError| WriteAuthConfigError::WriteAuthConfig {
+            source,
+            filename: GIT_CONFIG_FILENAME,
+        };
+
+        let writer = self.create_config_file(&[GIT_CONFIG_FILENAME]).await.map_err(mk_err)?;
+        self.write_auth_config_git_config_content(writer)
+            .await
+            .map_err(WriteConfigError::WriteContent)
+            .map_err(mk_err)
+    }
+
     /// Write the configuration for authenticating to registries
-    async fn write_auth_config_git_config(&self) -> Result<(), ApiError> {
-        let file = File::create(self.get_home_path_for(&[".gitconfig"])).await?;
-        let mut writer = BufWriter::new(file);
+    async fn write_auth_config_git_config_content(
+        &self,
+        mut writer: impl AsyncWrite + std::marker::Unpin,
+    ) -> Result<(), io::Error> {
         writer.write_all(b"[credential]\n    helper = store\n").await?;
-        writer.flush().await?;
-        Ok(())
+        writer.flush().await
     }
 
     /// Write the configuration for authenticating to registries
-    async fn write_auth_config_git_credentials(&self) -> Result<(), ApiError> {
-        let file = File::create(self.get_home_path_for(&[".git-credentials"])).await?;
-        let mut writer = BufWriter::new(file);
+    async fn write_auth_config_git_credentials(&self) -> Result<(), WriteAuthConfigError> {
+        const GIT_CREDENTIALS_FILENAME: &str = ".git-credentials";
+        let mk_err = |source: WriteConfigError| WriteAuthConfigError::WriteAuthConfig {
+            source,
+            filename: GIT_CREDENTIALS_FILENAME,
+        };
+
+        let writer = self.create_config_file(&[GIT_CREDENTIALS_FILENAME]).await.map_err(mk_err)?;
+        self.write_auth_config_git_credentials_content(writer)
+            .await
+            .map_err(WriteConfigError::WriteContent)
+            .map_err(mk_err)
+    }
+
+    async fn write_auth_config_git_credentials_content(
+        &self,
+        mut writer: impl AsyncWrite + std::marker::Unpin,
+    ) -> Result<(), io::Error> {
         let index = self.web_public_uri.find('/').unwrap() + 2;
         writer
             .write_all(
@@ -819,14 +846,21 @@ impl Configuration {
     }
 
     /// Write the configuration for authenticating to registries
-    async fn write_auth_config_cargo_config(&self) -> Result<(), WriteConfigError> {
-        let path = self.get_home_path_for(&[".cargo", "config.toml"]);
-        let file = File::create(&path)
+    async fn write_auth_cargo_config(&self) -> Result<(), WriteAuthConfigError> {
+        const CARGO_CONFIG_FILENAME: &str = "config.toml";
+        let mk_err = |source: WriteConfigError| WriteAuthConfigError::WriteAuthConfig {
+            source,
+            filename: CARGO_CONFIG_FILENAME,
+        };
+
+        let writer = self
+            .create_config_file(&[".cargo", CARGO_CONFIG_FILENAME])
             .await
-            .map_err(|source| WriteConfigError::CreateConfigToml { source, path })?;
-        self.write_auth_config_cargo_config_content(BufWriter::new(file))
+            .map_err(mk_err)?;
+        self.write_auth_config_cargo_config_content(writer)
             .await
             .map_err(WriteConfigError::WriteContent)
+            .map_err(mk_err)
     }
 
     async fn write_auth_config_cargo_config_content(&self, mut writer: BufWriter<File>) -> Result<(), io::Error> {
@@ -871,13 +905,28 @@ impl Configuration {
         Ok(())
     }
 
-    /// Write the configuration for authenticating to registries
-    async fn write_auth_config_cargo_credentials(&self) -> Result<(), WriteConfigError> {
-        let path = self.get_home_path_for(&[".cargo", "credentials.toml"]);
-        let file = File::create(&path)
+    async fn write_auth_config_cargo_credentials(&self) -> Result<(), WriteAuthConfigError> {
+        const CARGO_CREDENTIALS_FILENAME: &str = "credentials.toml";
+        let mk_err = |source: WriteConfigError| WriteAuthConfigError::WriteAuthConfig {
+            source,
+            filename: CARGO_CREDENTIALS_FILENAME,
+        };
+
+        let writer = self
+            .create_config_file(&[".cargo", CARGO_CREDENTIALS_FILENAME])
             .await
-            .map_err(|source| WriteConfigError::CreateConfigToml { source, path })?;
-        let mut writer = BufWriter::new(file);
+            .map_err(mk_err)?;
+        self.write_auth_config_cargo_credentials_content(writer)
+            .await
+            .map_err(WriteConfigError::WriteContent)
+            .map_err(mk_err)
+    }
+
+    /// Write the configuration for authenticating to registries
+    async fn write_auth_config_cargo_credentials_content(
+        &self,
+        mut writer: impl AsyncWrite + std::marker::Unpin,
+    ) -> Result<(), io::Error> {
         writer
             .write_all(format!("[registries.{}]\n", self.self_local_name).as_bytes())
             .await?;

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -14,7 +14,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::fs::File;
+use tokio::fs::{self, File};
 use tokio::io::{self, AsyncWrite, AsyncWriteExt, BufWriter};
 use tokio::process::Command;
 
@@ -26,6 +26,16 @@ use crate::utils::token::generate_token;
 
 #[derive(Debug, Error)]
 pub enum WriteConfigError {
+    #[error("failed to compute parent path for '{path}'")]
+    ParentPath { path: PathBuf },
+
+    #[error("failed to create folder '{path}'")]
+    CreateDir {
+        #[source]
+        source: io::Error,
+        path: PathBuf,
+    },
+
     #[error("failed to create file '{path}'")]
     CreateConfigFile {
         #[source]
@@ -765,6 +775,21 @@ impl Configuration {
 
     async fn create_config_file(&self, path: &[&str]) -> Result<BufWriter<File>, WriteConfigError> {
         let path = self.get_home_path_for(path);
+
+        // create parent folder if needed
+        let parent_path = path
+            .parent()
+            .ok_or_else(|| WriteConfigError::ParentPath { path: path.clone() })?;
+        if !parent_path.exists() {
+            fs::create_dir(parent_path)
+                .await
+                .map_err(|source| WriteConfigError::CreateDir {
+                    source,
+                    path: parent_path.to_path_buf(),
+                })?;
+        }
+
+        // create config file
         let file = File::create(&path)
             .await
             .map_err(|source| WriteConfigError::CreateConfigFile { source, path })?;

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -13,15 +13,42 @@ use axum::http::Uri;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use serde_derive::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::fs::File;
-use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::io::{self, AsyncWriteExt, BufWriter};
 use tokio::process::Command;
 
 use super::{CHANNEL_NIGHTLY, CHANNEL_STABLE};
 use crate::model::errors::MissingEnvVar;
-use crate::utils::apierror::{ApiError, error_backend_failure, specialize};
+use crate::utils::apierror::{ApiError, AsStatusCode, error_backend_failure, specialize};
 use crate::utils::comma_sep_to_vec;
 use crate::utils::token::generate_token;
+
+#[derive(Debug, Error)]
+pub enum WriteConfigError {
+    #[error("failed to write '{path}'")]
+    CreateConfigToml {
+        #[source]
+        source: io::Error,
+        path: PathBuf,
+    },
+
+    #[error("failed to write config file content")]
+    WriteContent(#[from] io::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum WriteAuthConfigError {
+    #[error("failed to write config.toml")]
+    WriteConfig(#[source] WriteConfigError),
+
+    #[error("failed to write credential.toml")]
+    WriteCredentials(#[source] WriteConfigError),
+
+    #[error("hack to allow progressiv work")]
+    ApiError,
+}
+impl AsStatusCode for WriteAuthConfigError {}
 
 /// Gets the value for an environment variable
 pub fn get_var<T: AsRef<str>>(name: T) -> Result<String, MissingEnvVar> {
@@ -728,13 +755,21 @@ impl Configuration {
     /// # Errors
     ///
     /// Return an error when writing fail
-    pub async fn write_auth_config(&self) -> Result<(), ApiError> {
+    pub async fn write_auth_config(&self) -> Result<(), WriteAuthConfigError> {
         if self.index.allow_protocol_git {
-            self.write_auth_config_git_config().await?;
-            self.write_auth_config_git_credentials().await?;
+            self.write_auth_config_git_config()
+                .await
+                .map_err(|_| WriteAuthConfigError::ApiError)?;
+            self.write_auth_config_git_credentials()
+                .await
+                .map_err(|_| WriteAuthConfigError::ApiError)?;
         }
-        self.write_auth_config_cargo_config().await?;
-        self.write_auth_config_cargo_credentials().await?;
+        self.write_auth_config_cargo_config()
+            .await
+            .map_err(WriteAuthConfigError::WriteConfig)?;
+        self.write_auth_config_cargo_credentials()
+            .await
+            .map_err(WriteAuthConfigError::WriteCredentials)?;
         Ok(())
     }
 
@@ -784,9 +819,17 @@ impl Configuration {
     }
 
     /// Write the configuration for authenticating to registries
-    async fn write_auth_config_cargo_config(&self) -> Result<(), ApiError> {
-        let file = File::create(self.get_home_path_for(&[".cargo", "config.toml"])).await?;
-        let mut writer = BufWriter::new(file);
+    async fn write_auth_config_cargo_config(&self) -> Result<(), WriteConfigError> {
+        let path = self.get_home_path_for(&[".cargo", "config.toml"]);
+        let file = File::create(&path)
+            .await
+            .map_err(|source| WriteConfigError::CreateConfigToml { source, path })?;
+        self.write_auth_config_cargo_config_content(BufWriter::new(file))
+            .await
+            .map_err(WriteConfigError::WriteContent)
+    }
+
+    async fn write_auth_config_cargo_config_content(&self, mut writer: BufWriter<File>) -> Result<(), io::Error> {
         writer.write_all(b"[registry]\n").await?;
         writer.write_all(b"global-credential-providers = [\"cargo:token\"]\n").await?;
         writer.write_all(b"\n").await?;
@@ -829,8 +872,11 @@ impl Configuration {
     }
 
     /// Write the configuration for authenticating to registries
-    async fn write_auth_config_cargo_credentials(&self) -> Result<(), ApiError> {
-        let file = File::create(self.get_home_path_for(&[".cargo", "credentials.toml"])).await?;
+    async fn write_auth_config_cargo_credentials(&self) -> Result<(), WriteConfigError> {
+        let path = self.get_home_path_for(&[".cargo", "credentials.toml"]);
+        let file = File::create(&path)
+            .await
+            .map_err(|source| WriteConfigError::CreateConfigToml { source, path })?;
         let mut writer = BufWriter::new(file);
         writer
             .write_all(format!("[registries.{}]\n", self.self_local_name).as_bytes())

--- a/src/model/errors.rs
+++ b/src/model/errors.rs
@@ -8,6 +8,8 @@ use std::env::VarError;
 
 use thiserror::Error;
 
+use crate::utils::apierror::AsStatusCode;
+
 /// Error when an environment error is missing
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("missing expected env var {var_name}")]
@@ -18,3 +20,4 @@ pub struct MissingEnvVar {
     /// The name of the variable
     pub var_name: String,
 }
+impl AsStatusCode for MissingEnvVar {}

--- a/src/model/errors.rs
+++ b/src/model/errors.rs
@@ -5,25 +5,16 @@
 //! Custom errors
 
 use std::env::VarError;
-use std::fmt::Display;
+
+use thiserror::Error;
 
 /// Error when an environment error is missing
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("missing expected env var {var_name}")]
 pub struct MissingEnvVar {
     /// The original error
+    #[source]
     pub original: VarError,
     /// The name of the variable
     pub var_name: String,
-}
-
-impl Display for MissingEnvVar {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "missing expected env var {}", self.var_name)
-    }
-}
-
-impl std::error::Error for MissingEnvVar {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.original)
-    }
 }

--- a/src/model/worker.rs
+++ b/src/model/worker.rs
@@ -12,6 +12,7 @@ use std::task::{Context, Poll, Waker};
 
 use log::{error, info};
 use serde_derive::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -277,19 +278,12 @@ impl Display for WorkerSelector {
 }
 
 /// Error when no worker matches the selector
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
+#[error("no connected worker matches the selector: {selector}")]
 pub struct NoMatchingWorkerError {
     /// The selector that was used
     pub selector: WorkerSelector,
 }
-
-impl Display for NoMatchingWorkerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "no connected worker matches the selector: {}", self.selector)
-    }
-}
-
-impl std::error::Error for NoMatchingWorkerError {}
 
 /// Wait for a worker
 pub struct WorkerWaiter {

--- a/src/model/worker.rs
+++ b/src/model/worker.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 use super::docs::{DocGenJob, DocGenJobUpdate};
 use crate::model::config::{Configuration, NodeRole};
-use crate::utils::apierror::ApiError;
+use crate::utils::apierror::{ApiError, AsStatusCode};
 use crate::utils::token::generate_token;
 
 /// The descriptor of a worker and its capabilities
@@ -284,6 +284,7 @@ pub struct NoMatchingWorkerError {
     /// The selector that was used
     pub selector: WorkerSelector,
 }
+impl AsStatusCode for NoMatchingWorkerError {}
 
 /// Wait for a worker
 pub struct WorkerWaiter {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -369,7 +369,11 @@ pub async fn api_v1_login_with_oauth_code(
     body: Bytes,
 ) -> Result<(StatusCode, [(HeaderName, HeaderValue); 1], Json<RegistryUser>), (StatusCode, Json<ApiError>)> {
     let code = String::from_utf8_lossy(&body);
-    let registry_user = state.application.login_with_oauth_code(&code).await.map_err(response_error)?;
+    let registry_user = state
+        .application
+        .login_with_oauth_code(&code)
+        .await
+        .map_err(|err| response_error(ApiError::from(err)))?;
     let cookie = auth_data.create_id_cookie(&Authentication::new_user(registry_user.id, registry_user.email.clone()));
     Ok((
         StatusCode::OK,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -789,9 +789,9 @@ pub async fn api_v1_download_crate(
             data,
         )),
         Err(mut error) => {
-            if error.http == 401 {
-                // map to 403
-                error.http = 403;
+            if error.http == StatusCode::UNAUTHORIZED {
+                // map UNAUTHORIZED - 401 to FORBIDDEN - 403
+                error.http = StatusCode::FORBIDDEN;
             }
             Err(response_error(error))
         }

--- a/src/services/database/admin.rs
+++ b/src/services/database/admin.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 
 use super::Database;
 use crate::model::auth::{RegistryUserToken, RegistryUserTokenWithSecret};
-use crate::utils::apierror::{ApiError, AsStatusCode};
+use crate::utils::apierror::AsStatusCode;
 use crate::utils::token::{generate_token, hash_token};
 
 #[derive(Debug, Error)]
@@ -33,7 +33,7 @@ impl AsStatusCode for TokensError {
 
 impl Database {
     /// Gets the global tokens for the registry, usually for CI purposes
-    pub async fn get_global_tokens(&self) -> Result<Vec<RegistryUserToken>, ApiError> {
+    pub async fn get_global_tokens(&self) -> Result<Vec<RegistryUserToken>, sqlx::Error> {
         let rows = sqlx::query!("SELECT id, name, lastUsed AS last_used FROM RegistryGlobalToken ORDER BY id",)
             .fetch_all(&mut *self.transaction.borrow().await)
             .await?;

--- a/src/services/database/jobs.rs
+++ b/src/services/database/jobs.rs
@@ -216,7 +216,7 @@ impl Database {
     }
 
     /// Updates an existing job
-    pub async fn update_docgen_job(&self, job_id: i64, state: DocGenJobState) -> Result<(), ApiError> {
+    pub async fn update_docgen_job(&self, job_id: i64, state: DocGenJobState) -> Result<(), sqlx::Error> {
         let now = Local::now().naive_local();
         let state_value = state.value();
         if state == DocGenJobState::Working {

--- a/src/services/database/jobs.rs
+++ b/src/services/database/jobs.rs
@@ -5,13 +5,14 @@
 //! Service for persisting information in the database
 //! API related to jobs
 
+use axum::http::StatusCode;
 use chrono::Local;
 use thiserror::Error;
 
 use super::Database;
 use super::users::UserError;
 use crate::model::docs::{DocGenJob, DocGenJobSpec, DocGenJobState, DocGenTrigger};
-use crate::utils::apierror::{ApiError, AsStatusCode, error_not_found};
+use crate::utils::apierror::AsStatusCode;
 use crate::utils::comma_sep_to_vec;
 
 #[derive(Debug, Error)]
@@ -36,13 +37,48 @@ pub enum DocGenError {
         spec_version: String,
         spec_target: String,
     },
+
+    #[error("failed to execute DB request to get next job")]
+    SqlGetNextJob(#[source] sqlx::Error),
+
+    #[error("failed to execute DB request to get Docgen jobs")]
+    SqlGetDocgenJobs(#[source] sqlx::Error),
+
+    #[error("failed to execute DB request to get Docgen job for `{job_id}`")]
+    SqlGetDocgenJob {
+        #[source]
+        source: sqlx::Error,
+        job_id: i64,
+    },
+
+    #[error("failed to get user profile for `{uid}`")]
+    GetUserProfile {
+        #[source]
+        source: UserError,
+        uid: i64,
+    },
+
+    #[error("job `{job_id}` not found")]
+    JobNotFound { job_id: i64 },
 }
 
-impl AsStatusCode for DocGenError {}
+impl AsStatusCode for DocGenError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::SqlxSelectJob { .. }
+            | Self::SqlxInsertJob { .. }
+            | Self::SqlGetNextJob(_)
+            | Self::SqlGetDocgenJobs(_)
+            | Self::SqlGetDocgenJob { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::UserProfile(user_error) | Self::GetUserProfile { source: user_error, .. } => user_error.status_code(),
+            Self::JobNotFound { .. } => StatusCode::NOT_FOUND,
+        }
+    }
+}
 
 impl Database {
     /// Gets the documentation generation jobs
-    pub async fn get_docgen_jobs(&self) -> Result<Vec<DocGenJob>, ApiError> {
+    pub async fn get_docgen_jobs(&self) -> Result<Vec<DocGenJob>, DocGenError> {
         let rows = sqlx::query!(
             "SELECT id, package, version, target, useNative AS usenative, capabilities, state,
             queuedOn AS queued_on, startedOn AS started_on, finishedOn AS finished_on, lastUpdate AS last_update,
@@ -51,7 +87,8 @@ impl Database {
             ORDER BY id DESC"
         )
         .fetch_all(&mut *self.transaction.borrow().await)
-        .await?;
+        .await
+        .map_err(DocGenError::SqlGetDocgenJobs)?;
         let mut jobs = Vec::with_capacity(rows.len());
         for row in rows {
             jobs.push(DocGenJob {
@@ -69,7 +106,11 @@ impl Database {
                 trigger: DocGenTrigger::from((
                     row.trigger_event,
                     if let Some(uid) = row.trigger_user {
-                        Some(self.get_user_profile(uid).await?)
+                        Some(
+                            self.get_user_profile(uid)
+                                .await
+                                .map_err(|source| DocGenError::GetUserProfile { source, uid })?,
+                        )
                     } else {
                         None
                     },
@@ -80,7 +121,7 @@ impl Database {
     }
 
     /// Gets a single documentation job
-    pub async fn get_docgen_job(&self, job_id: i64) -> Result<DocGenJob, ApiError> {
+    pub async fn get_docgen_job(&self, job_id: i64) -> Result<DocGenJob, DocGenError> {
         let row = sqlx::query!(
             "SELECT id, package, version, target, useNative AS usenative, capabilities, state,
             queuedOn AS queued_on, startedOn AS started_on, finishedOn AS finished_on, lastUpdate AS last_update,
@@ -91,8 +132,9 @@ impl Database {
             job_id
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
-        .await?
-        .ok_or_else(error_not_found)?;
+        .await
+        .map_err(|source| DocGenError::SqlGetDocgenJob { source, job_id })?
+        .ok_or_else(|| DocGenError::JobNotFound { job_id })?;
         Ok(DocGenJob {
             id: row.id,
             package: row.package,
@@ -108,7 +150,11 @@ impl Database {
             trigger: DocGenTrigger::from((
                 row.trigger_event,
                 if let Some(uid) = row.trigger_user {
-                    Some(self.get_user_profile(uid).await?)
+                    Some(
+                        self.get_user_profile(uid)
+                            .await
+                            .map_err(|source| DocGenError::GetUserProfile { source, uid })?,
+                    )
                 } else {
                     None
                 },
@@ -218,7 +264,7 @@ impl Database {
     }
 
     /// Attempts to get the next available job
-    pub async fn get_next_docgen_job(&self) -> Result<Option<DocGenJob>, ApiError> {
+    pub async fn get_next_docgen_job(&self) -> Result<Option<DocGenJob>, DocGenError> {
         let state_value = DocGenJobState::Queued.value();
         let row = sqlx::query!(
             "SELECT id, package, version, target, useNative AS usenative, capabilities, state,
@@ -231,7 +277,8 @@ impl Database {
             state_value
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
-        .await?;
+        .await
+        .map_err(DocGenError::SqlGetNextJob)?;
         let Some(row) = row else { return Ok(None) };
         Ok(Some(DocGenJob {
             id: row.id,
@@ -248,7 +295,11 @@ impl Database {
             trigger: DocGenTrigger::from((
                 row.trigger_event,
                 if let Some(uid) = row.trigger_user {
-                    Some(self.get_user_profile(uid).await?)
+                    Some(
+                        self.get_user_profile(uid)
+                            .await
+                            .map_err(|source| DocGenError::GetUserProfile { source, uid })?,
+                    )
                 } else {
                     None
                 },

--- a/src/services/database/mod.rs
+++ b/src/services/database/mod.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 
 use crate::application::AuthenticationError;
 use crate::model::auth::ROLE_ADMIN;
-use crate::utils::apierror::{ApiError, AsStatusCode, error_forbidden, error_not_found};
+use crate::utils::apierror::{ApiError, AsStatusCode, error_not_found};
 use crate::utils::db::{AppTransaction, RwSqlitePool};
 
 /// Executes a piece of work in the context of a transaction
@@ -115,9 +115,13 @@ impl Database {
     }
 
     /// Checks that a user is an admin
-    pub async fn check_is_admin(&self, uid: i64) -> Result<(), ApiError> {
+    pub async fn check_is_admin(&self, uid: i64) -> Result<(), AuthenticationError> {
         let is_admin = self.get_is_admin(uid).await?;
-        if is_admin { Ok(()) } else { Err(error_forbidden()) }
+        if is_admin {
+            Ok(())
+        } else {
+            Err(AuthenticationError::AdministrationIsForbidden)
+        }
     }
 
     /// Checks that a package exists

--- a/src/services/database/mod.rs
+++ b/src/services/database/mod.rs
@@ -61,11 +61,15 @@ where
 /// # Errors
 ///
 /// Returns an instance of the `E` type argument
-pub async fn db_transaction_write<F, FUT, T, E>(pool: &RwSqlitePool, operation: &'static str, workload: F) -> Result<T, E>
+pub async fn db_transaction_write<F, FUT, T, E>(
+    pool: &RwSqlitePool,
+    operation: &'static str,
+    workload: F,
+) -> Result<T, ApiError>
 where
     F: FnOnce(Database) -> FUT,
     FUT: Future<Output = Result<T, E>>,
-    E: From<sqlx::Error>,
+    E: AsStatusCode + std::marker::Send + std::marker::Sync + 'static,
 {
     let transaction = pool.acquire_write(operation).await?;
     let result = {
@@ -82,7 +86,7 @@ where
         }
         Err(error) => {
             transaction.rollback().await?;
-            Err(error)
+            Err(ApiError::from(error))
         }
     }
 }

--- a/src/services/database/mod.rs
+++ b/src/services/database/mod.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use crate::application::AuthenticationError;
 use crate::model::auth::ROLE_ADMIN;
 use crate::services::database::packages::CratesError;
-use crate::utils::apierror::AsStatusCode;
+use crate::utils::apierror::{ApiError, AsStatusCode};
 use crate::utils::db::{AppTransaction, RwSqlitePool};
 
 /// Executes a piece of work in the context of a transaction
@@ -28,11 +28,11 @@ use crate::utils::db::{AppTransaction, RwSqlitePool};
 /// # Errors
 ///
 /// Returns an instance of the `E` type argument
-pub async fn db_transaction_read<F, FUT, T, E>(pool: &RwSqlitePool, workload: F) -> Result<T, E>
+pub async fn db_transaction_read<F, FUT, T, E>(pool: &RwSqlitePool, workload: F) -> Result<T, ApiError>
 where
     F: FnOnce(Database) -> FUT,
     FUT: Future<Output = Result<T, E>>,
-    E: From<sqlx::Error>,
+    E: AsStatusCode + std::marker::Send + std::marker::Sync + 'static,
 {
     let transaction = pool.acquire_read().await?;
     let result = {
@@ -49,7 +49,7 @@ where
         }
         Err(error) => {
             transaction.rollback().await?;
-            Err(error)
+            Err(ApiError::from(error))
         }
     }
 }

--- a/src/services/database/mod.rs
+++ b/src/services/database/mod.rs
@@ -104,11 +104,12 @@ impl Database {
     }
 
     /// Checks that a user is an admin
-    pub async fn get_is_admin(&self, uid: i64) -> Result<bool, ApiError> {
+    pub async fn get_is_admin(&self, uid: i64) -> Result<bool, AuthenticationError> {
         let roles = sqlx::query!("SELECT roles FROM RegistryUser WHERE id = $1", uid)
             .fetch_optional(&mut *self.transaction.borrow().await)
-            .await?
-            .ok_or_else(error_forbidden)?
+            .await
+            .map_err(AuthenticationError::CheckRoles)?
+            .ok_or(AuthenticationError::Forbidden)?
             .roles;
         Ok(roles.split(',').any(|role| role.trim() == ROLE_ADMIN))
     }

--- a/src/services/database/packages.rs
+++ b/src/services/database/packages.rs
@@ -16,17 +16,18 @@ use semver::Version;
 use smol_str::SmolStr;
 use thiserror::Error;
 
-use super::Database;
+use super::{Database, IsCrateManagerError, users::UserError};
+use crate::application::AuthenticationError;
 use crate::model::CrateVersion;
 use crate::model::cargo::{
-    CrateUploadData, CrateUploadResult, IndexCrateMetadata, OwnersQueryResult, RegistryUser, SearchResultCrate, SearchResults,
-    SearchResultsMeta, YesNoMsgResult, YesNoResult,
+    CrateNameError, CrateUploadData, CrateUploadResult, IndexCrateMetadata, OwnersQueryResult, RegistryUser, SearchResultCrate,
+    SearchResults, SearchResultsMeta, YesNoMsgResult, YesNoResult,
 };
 use crate::model::deps::{DepsAnalysisJobSpec, DepsAnalysisState};
 use crate::model::docs::DocGenJobSpec;
 use crate::model::packages::{CrateInfo, CrateInfoTarget, CrateInfoVersion, CrateInfoVersionDocs};
 use crate::model::stats::{DownloadStats, SERIES_LENGTH};
-use crate::utils::apierror::{ApiError, AsStatusCode, error_invalid_request, error_not_found, specialize};
+use crate::utils::apierror::AsStatusCode;
 use crate::utils::comma_sep_to_vec;
 
 #[derive(Debug, Error)]
@@ -51,14 +52,75 @@ pub enum CratesError {
     #[error("package (crate) not found : {package}")]
     PackageNotFound { package: String },
 
+    #[error("package {package}, version {version} not found")]
+    PackageVersionNotFound { package: String, version: SmolStr },
+
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
+
+    #[error(transparent)]
+    CrateManager(#[from] IsCrateManagerError),
+
+    #[error("package {name} already exists in version {version}, uploaded on {dest}")]
+    PackageAlreadyExistInVersion { name: String, version: SmolStr, dest: String },
+
+    #[error("a package named {0} already exists")]
+    PackageAlreadyExist(String),
+
+    #[error("metadata are invalid")]
+    Metadata(#[from] CrateNameError),
+
+    #[error("failed to get user info for uid `{uid}`")]
+    UserProfile {
+        #[source]
+        source: UserError,
+        uid: i64,
+    },
+    #[error("the user '{email}' is not known")]
+    IsUser {
+        #[source]
+        source: AuthenticationError,
+        email: String,
+    },
+
+    #[error("package {package} does not allow removing versions")]
+    PackageNotAllowRemoveVersion { package: String },
+
+    #[error("version {version} of crate {package} does not exist")]
+    PackageNotExistInVersion { package: String, version: SmolStr },
+
+    #[error("version {version} of crate {package} is already yanked")]
+    AlreadyYanked { package: String, version: SmolStr },
+
+    #[error("version {version} of crate {package} is not yanked")]
+    PackageVersionNotYanked { package: String, version: SmolStr },
+
+    #[error("failed to parse package version `{version}`")]
+    ParseVersion {
+        #[source]
+        source: semver::Error,
+        version: SmolStr,
+    },
+
+    #[error("cannot remove all owners")]
+    RemoveAllOwners,
 }
 impl AsStatusCode for CratesError {
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::PackageNotFound { .. } => StatusCode::NOT_FOUND,
-            Self::Sqlx(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::PackageNotFound { .. } | Self::PackageVersionNotFound { .. } => StatusCode::NOT_FOUND,
+            Self::Sqlx(_) | Self::UserProfile { .. } | Self::IsUser { .. } | Self::ParseVersion { .. } => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Self::Metadata(crate_name_error) => crate_name_error.status_code(),
+            Self::CrateManager(err) => err.status_code(),
+            Self::PackageAlreadyExistInVersion { .. }
+            | Self::PackageAlreadyExist(_)
+            | Self::PackageNotAllowRemoveVersion { .. }
+            | Self::PackageNotExistInVersion { .. }
+            | Self::AlreadyYanked { .. }
+            | Self::RemoveAllOwners
+            | Self::PackageVersionNotYanked { .. } => StatusCode::BAD_REQUEST,
         }
     }
 }
@@ -70,7 +132,7 @@ impl Database {
         query: &str,
         per_page: Option<usize>,
         deprecated: Option<bool>,
-    ) -> Result<SearchResults, ApiError> {
+    ) -> Result<SearchResults, sqlx::Error> {
         let per_page = match per_page {
             None => 10,
             Some(value) if value > 100 => 100,
@@ -111,7 +173,7 @@ impl Database {
     }
 
     /// Gets whether the database does not contain any package at all
-    pub async fn get_is_empty(&self) -> Result<bool, ApiError> {
+    pub async fn get_is_empty(&self) -> Result<bool, sqlx::Error> {
         Ok(sqlx::query!("SELECT id FROM PackageVersion LIMIT 1")
             .fetch_optional(&mut *self.transaction.borrow().await)
             .await?
@@ -119,14 +181,14 @@ impl Database {
     }
 
     /// Gets the last version number for a package
-    pub async fn get_crate_last_version(&self, package: &str) -> Result<String, ApiError> {
+    pub async fn get_crate_last_version(&self, package: &str) -> Result<String, CratesError> {
         let row = sqlx::query!(
             "SELECT version, description FROM PackageVersion WHERE package = $1 AND yanked = FALSE ORDER BY id DESC LIMIT 1",
             package
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         Ok(row.version)
     }
 
@@ -135,14 +197,14 @@ impl Database {
         &self,
         package: &str,
         versions_in_index: Vec<IndexCrateMetadata>,
-    ) -> Result<CrateInfo, ApiError> {
+    ) -> Result<CrateInfo, CratesError> {
         let row = sqlx::query!(
             "SELECT isDeprecated AS is_deprecated, canRemove AS can_remove, targets, nativeTargets AS nativetargets, capabilities FROM Package WHERE name = $1 LIMIT 1",
             package
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         let is_deprecated = row.is_deprecated;
         let can_remove = row.can_remove;
         let targets = comma_sep_to_vec(&row.targets);
@@ -161,7 +223,13 @@ impl Database {
         let mut versions = Vec::new();
         for index_data in versions_in_index {
             if let Some(row) = rows.iter().find(|row| row.version == index_data.vers) {
-                let uploaded_by = self.get_user_profile(row.uploaded_by).await?;
+                let uploaded_by = self
+                    .get_user_profile(row.uploaded_by)
+                    .await
+                    .map_err(|source| CratesError::UserProfile {
+                        source,
+                        uid: row.uploaded_by,
+                    })?;
                 versions.push(CrateInfoVersion {
                     index: index_data,
                     upload: row.upload,
@@ -208,7 +276,7 @@ impl Database {
     }
 
     /// Publish a crate
-    pub async fn publish_crate_version(&self, uid: i64, package: &CrateUploadData) -> Result<CrateUploadResult, ApiError> {
+    pub async fn publish_crate_version(&self, uid: i64, package: &CrateUploadData) -> Result<CrateUploadResult, CratesError> {
         let warnings = package.metadata.validate()?;
         let lowercase = package.metadata.name.to_ascii_lowercase();
         let row = sqlx::query!(
@@ -219,13 +287,11 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         if let Some(row) = row {
-            return Err(specialize(
-                error_invalid_request(),
-                format!(
-                    "Package {} already exists in version {}, uploaded on {}",
-                    &package.metadata.name, &package.metadata.vers, row.upload
-                ),
-            ));
+            return Err(CratesError::PackageAlreadyExistInVersion {
+                name: package.metadata.name.clone(),
+                version: package.metadata.vers.clone().into(),
+                dest: row.upload.to_string(),
+            });
         }
         // check whether the package already exists
         let row = sqlx::query!("SELECT name FROM Package WHERE lowercase = $1 LIMIT 1", lowercase)
@@ -234,10 +300,7 @@ impl Database {
         if let Some(row) = row {
             // check this is the same package
             if row.name != lowercase {
-                return Err(specialize(
-                    error_invalid_request(),
-                    format!("A package named {} already exists", row.name),
-                ));
+                return Err(CratesError::PackageAlreadyExist(row.name));
             }
             // check the ownership
             self.check_is_crate_manager(uid, &package.metadata.name).await?;
@@ -276,7 +339,7 @@ impl Database {
     }
 
     /// Completely removes a version from the registry
-    pub async fn remove_crate_version(&self, package: &str, version: &str) -> Result<(), ApiError> {
+    pub async fn remove_crate_version(&self, package: &str, version: &str) -> Result<(), CratesError> {
         // check whether this is allowed
         let can_remove = sqlx::query!(
             "SELECT canRemove AS can_remove FROM Package WHERE lowercase = $1 LIMIT 1",
@@ -286,10 +349,7 @@ impl Database {
         .await?
         .is_some_and(|r| r.can_remove);
         if !can_remove {
-            return Err(specialize(
-                error_invalid_request(),
-                format!("Package {package} does not allow removing versions",),
-            ));
+            return Err(CratesError::PackageNotAllowRemoveVersion { package: package.into() });
         }
         // check version exists
         let row = sqlx::query!(
@@ -300,10 +360,10 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         if row.is_none() {
-            return Err(specialize(
-                error_not_found(),
-                format!("Package {package}, version {version} not found",),
-            ));
+            return Err(CratesError::PackageVersionNotFound {
+                package: package.into(),
+                version: version.into(),
+            });
         }
         sqlx::query!(
             "DELETE FROM PackageVersion WHERE package = $1 AND version = $2",
@@ -324,7 +384,7 @@ impl Database {
     }
 
     /// Yank a crate version
-    pub async fn yank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, ApiError> {
+    pub async fn yank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, CratesError> {
         let row = sqlx::query!(
             "SELECT yanked FROM PackageVersion WHERE package = $1 AND version = $2 LIMIT 1",
             package,
@@ -333,16 +393,16 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         match row {
-            None => Err(specialize(
-                error_invalid_request(),
-                format!("Version {version} of crate {package} does not exist"),
-            )),
+            None => Err(CratesError::PackageNotExistInVersion {
+                package: package.into(),
+                version: version.into(),
+            }),
             Some(row) => {
                 if row.yanked {
-                    Err(specialize(
-                        error_invalid_request(),
-                        format!("Version {version} of crate {package} is already yanked"),
-                    ))
+                    Err(CratesError::AlreadyYanked {
+                        package: package.into(),
+                        version: version.into(),
+                    })
                 } else {
                     sqlx::query!(
                         "UPDATE PackageVersion SET yanked = TRUE WHERE package = $1 AND version = $2",
@@ -358,7 +418,7 @@ impl Database {
     }
 
     /// Unyank a crate version
-    pub async fn unyank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, ApiError> {
+    pub async fn unyank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, CratesError> {
         let row = sqlx::query!(
             "SELECT yanked FROM PackageVersion WHERE package = $1 AND version = $2 LIMIT 1",
             package,
@@ -367,10 +427,10 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         match row {
-            None => Err(specialize(
-                error_invalid_request(),
-                format!("Version {version} of crate {package} does not exist"),
-            )),
+            None => Err(CratesError::PackageNotExistInVersion {
+                package: package.into(),
+                version: version.into(),
+            }),
             Some(row) => {
                 if row.yanked {
                     sqlx::query!(
@@ -382,10 +442,10 @@ impl Database {
                     .await?;
                     Ok(YesNoResult::new())
                 } else {
-                    Err(specialize(
-                        error_invalid_request(),
-                        format!("Version {version} of crate {package} is not yanked"),
-                    ))
+                    Err(CratesError::PackageVersionNotYanked {
+                        package: package.into(),
+                        version: version.into(),
+                    })
                 }
             }
         }
@@ -487,7 +547,7 @@ impl Database {
         target: &str,
         is_attempted: bool,
         is_present: bool,
-    ) -> Result<(), ApiError> {
+    ) -> Result<(), sqlx::Error> {
         let is_missing = sqlx::query!(
             "SELECT id FROM PackageVersionDocs WHERE package = $1 AND version = $2 AND target = $3 LIMIT 1",
             package,
@@ -522,7 +582,7 @@ impl Database {
         package: &str,
         version: &str,
         default_target: &str,
-    ) -> Result<Vec<CrateInfoTarget>, ApiError> {
+    ) -> Result<Vec<CrateInfoTarget>, CratesError> {
         self.check_crate_exists(package, version).await?;
 
         let row = sqlx::query!(
@@ -531,7 +591,7 @@ impl Database {
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         let targets = comma_sep_to_vec(&row.targets);
         let native_targets = comma_sep_to_vec(&row.nativetargets);
         let targets = targets
@@ -559,7 +619,7 @@ impl Database {
 
     /// Gets the packages that need to have their dependencies analyzed
     /// Those are the latest version of each crate
-    pub async fn get_unanalyzed_crates(&self, deps_stale_analysis: i64) -> Result<Vec<DepsAnalysisJobSpec>, ApiError> {
+    pub async fn get_unanalyzed_crates(&self, deps_stale_analysis: i64) -> Result<Vec<DepsAnalysisJobSpec>, CratesError> {
         let now = Local::now().naive_local();
         let from = now - Duration::minutes(deps_stale_analysis);
         let heads = self.get_crates_version_heads().await?;
@@ -576,7 +636,7 @@ impl Database {
     }
 
     /// Gets all the packages that are outdated while also being the latest version
-    pub async fn get_crates_outdated_heads(&self) -> Result<Vec<CrateVersion>, ApiError> {
+    pub async fn get_crates_outdated_heads(&self) -> Result<Vec<CrateVersion>, CratesError> {
         let heads = self.get_crates_version_heads().await?;
         Ok(heads
             .into_iter()
@@ -591,7 +651,7 @@ impl Database {
     }
 
     /// Gets all the latest version of crates, filtering out yanked and pre-release versions
-    async fn get_crates_version_heads(&self) -> Result<Vec<DepsAnalysisState>, ApiError> {
+    async fn get_crates_version_heads(&self) -> Result<Vec<DepsAnalysisState>, CratesError> {
         struct Elem {
             semver: Version,
             version: String,
@@ -612,7 +672,10 @@ impl Database {
         while let Some(row) = stream.next().await {
             let row = row?;
             let name = row.package;
-            let semver = row.version.parse::<Version>()?;
+            let semver = row.version.parse::<Version>().map_err(|source| CratesError::ParseVersion {
+                source,
+                version: row.version.clone().into(),
+            })?;
             if semver.pre.is_empty() {
                 // not a pre-release
                 match cache.entry(name.clone()) {
@@ -723,7 +786,7 @@ impl Database {
     }
 
     /// Gets the download statistics for a crate
-    pub async fn get_crate_dl_stats(&self, package: &str) -> Result<DownloadStats, ApiError> {
+    pub async fn get_crate_dl_stats(&self, package: &str) -> Result<DownloadStats, CratesError> {
         let rows = sqlx::query!("SELECT version, downloads FROM PackageVersion WHERE package = $1", package)
             .fetch_all(&mut *self.transaction.borrow().await)
             .await?;
@@ -736,14 +799,14 @@ impl Database {
     }
 
     /// Gets the list of owners for a package
-    pub async fn get_crate_owners(&self, package: &str) -> Result<OwnersQueryResult, ApiError> {
+    pub async fn get_crate_owners(&self, package: &str) -> Result<OwnersQueryResult, CratesError> {
         let users = sqlx::query_as!(RegistryUser, "SELECT RegistryUser.id, isActive AS is_active, email, login, name, roles FROM RegistryUser INNER JOIN PackageOwner ON PackageOwner.owner = RegistryUser.id WHERE package = $1", package)
             .fetch_all(&mut *self.transaction.borrow().await).await?;
         Ok(OwnersQueryResult { users })
     }
 
     /// Add owners to a package
-    pub async fn add_crate_owners(&self, package: &str, new_users: &[String]) -> Result<YesNoMsgResult, ApiError> {
+    pub async fn add_crate_owners(&self, package: &str, new_users: &[String]) -> Result<YesNoMsgResult, CratesError> {
         // get all current owners
         let rows = sqlx::query!("SELECT owner FROM PackageOwner WHERE package = $1", package,)
             .fetch_all(&mut *self.transaction.borrow().await)
@@ -751,7 +814,10 @@ impl Database {
         // add new users
         let mut added = Vec::new();
         for new_user in new_users {
-            let new_uid = self.check_is_user(new_user).await?;
+            let new_uid = self.check_is_user(new_user).await.map_err(|source| CratesError::IsUser {
+                source,
+                email: new_user.into(),
+            })?;
             if rows.iter().all(|r| r.owner != new_uid) {
                 // not already an owner
                 sqlx::query!("INSERT INTO PackageOwner (package, owner) VALUES ($1, $2)", package, new_uid)
@@ -769,7 +835,7 @@ impl Database {
     }
 
     /// Remove owners from a package
-    pub async fn remove_crate_owners(&self, package: &str, old_users: &[String]) -> Result<YesNoResult, ApiError> {
+    pub async fn remove_crate_owners(&self, package: &str, old_users: &[String]) -> Result<YesNoResult, CratesError> {
         // get all current owners
         let rows = sqlx::query!("SELECT owner FROM PackageOwner WHERE package = $1", package,)
             .fetch_all(&mut *self.transaction.borrow().await)
@@ -777,7 +843,10 @@ impl Database {
         let mut current_owners: Vec<i64> = rows.into_iter().map(|r| r.owner).collect();
         // remove old users
         for old_user in old_users {
-            let old_uid = self.check_is_user(old_user).await?;
+            let old_uid = self.check_is_user(old_user).await.map_err(|source| CratesError::IsUser {
+                source,
+                email: old_user.into(),
+            })?;
             let index = current_owners
                 .iter()
                 .enumerate()
@@ -786,7 +855,7 @@ impl Database {
             if let Some(index) = index {
                 if current_owners.len() == 1 {
                     // cannot remove the last one
-                    return Err(specialize(error_invalid_request(), String::from("Cannot remove all owners")));
+                    return Err(CratesError::RemoveAllOwners);
                 }
                 // not already an owner
                 sqlx::query!("DELETE FROM PackageOwner WHERE package = $1 AND owner = $2", package, old_uid)
@@ -799,14 +868,14 @@ impl Database {
     }
 
     /// Gets the targets for a crate
-    pub async fn get_crate_targets(&self, package: &str) -> Result<Vec<CrateInfoTarget>, ApiError> {
+    pub async fn get_crate_targets(&self, package: &str) -> Result<Vec<CrateInfoTarget>, CratesError> {
         let row = sqlx::query!(
             "SELECT targets, nativeTargets AS nativetargets FROM Package WHERE name = $1 LIMIT 1",
             package
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         let targets = comma_sep_to_vec(&row.targets);
         let native_targets = comma_sep_to_vec(&row.nativetargets);
         Ok(targets
@@ -819,7 +888,11 @@ impl Database {
     }
 
     /// Sets the targets for a crate
-    pub async fn set_crate_targets(&self, package: &str, targets: &[CrateInfoTarget]) -> Result<Vec<DocGenJobSpec>, ApiError> {
+    pub async fn set_crate_targets(
+        &self,
+        package: &str,
+        targets: &[CrateInfoTarget],
+    ) -> Result<Vec<DocGenJobSpec>, CratesError> {
         let old_targets = self.get_crate_targets(package).await?;
         let added_targets = targets
             .iter()

--- a/src/services/database/packages.rs
+++ b/src/services/database/packages.rs
@@ -16,17 +16,18 @@ use semver::Version;
 use smol_str::SmolStr;
 use thiserror::Error;
 
-use super::Database;
+use super::{Database, IsCrateManagerError, users::UserError};
+use crate::application::AuthenticationError;
 use crate::model::CrateVersion;
 use crate::model::cargo::{
-    CrateUploadData, CrateUploadResult, IndexCrateMetadata, OwnersQueryResult, RegistryUser, SearchResultCrate, SearchResults,
-    SearchResultsMeta, YesNoMsgResult, YesNoResult,
+    CrateNameError, CrateUploadData, CrateUploadResult, IndexCrateMetadata, OwnersQueryResult, RegistryUser, SearchResultCrate,
+    SearchResults, SearchResultsMeta, YesNoMsgResult, YesNoResult,
 };
 use crate::model::deps::{DepsAnalysisJobSpec, DepsAnalysisState};
 use crate::model::docs::DocGenJobSpec;
 use crate::model::packages::{CrateInfo, CrateInfoTarget, CrateInfoVersion, CrateInfoVersionDocs};
 use crate::model::stats::{DownloadStats, SERIES_LENGTH};
-use crate::utils::apierror::{ApiError, AsStatusCode, error_invalid_request, error_not_found, specialize};
+use crate::utils::apierror::AsStatusCode;
 use crate::utils::comma_sep_to_vec;
 
 #[derive(Debug, Error)]
@@ -51,14 +52,75 @@ pub enum CratesError {
     #[error("package (crate) not found : {package}")]
     PackageNotFound { package: String },
 
+    #[error("package {package}, version {version} not found")]
+    PackageVersionNotFound { package: String, version: SmolStr },
+
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
+
+    #[error(transparent)]
+    CrateManager(#[from] IsCrateManagerError),
+
+    #[error("package {name} already exists in version {version}, uploaded on {dest}")]
+    PackageAlreadyExistInVersion { name: String, version: SmolStr, dest: String },
+
+    #[error("a package named {0} already exists")]
+    PackageAlreadyExist(String),
+
+    #[error("metadata are invalid")]
+    Metadata(#[from] CrateNameError),
+
+    #[error("failed to get user info for uid `{uid}`")]
+    UserProfile {
+        #[source]
+        source: UserError,
+        uid: i64,
+    },
+    #[error("the user '{email}' is not known")]
+    IsUser {
+        #[source]
+        source: AuthenticationError,
+        email: String,
+    },
+
+    #[error("package {package} does not allow removing versions")]
+    PackageNotAllowRemoveVersion { package: String },
+
+    #[error("version {version} of crate {package} does not exist")]
+    PackageNotExistInVersion { package: String, version: SmolStr },
+
+    #[error("version {version} of crate {package} is already yanked")]
+    AlreadyYanked { package: String, version: SmolStr },
+
+    #[error("version {version} of crate {package} is not yanked")]
+    PackageVersionNotYanked { package: String, version: SmolStr },
+
+    #[error("failed to parse package version `{version}`")]
+    ParseVersion {
+        #[source]
+        source: semver::Error,
+        version: SmolStr,
+    },
+
+    #[error("cannot remove all owners")]
+    RemoveAllOwners,
 }
 impl AsStatusCode for CratesError {
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::PackageNotFound { .. } => StatusCode::NOT_FOUND,
-            Self::Sqlx(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::PackageNotFound { .. } | Self::PackageVersionNotFound { .. } => StatusCode::NOT_FOUND,
+            Self::Sqlx(_) | Self::UserProfile { .. } | Self::IsUser { .. } | Self::ParseVersion { .. } => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Self::Metadata(crate_name_error) => crate_name_error.status_code(),
+            Self::CrateManager(err) => err.status_code(),
+            Self::PackageAlreadyExistInVersion { .. }
+            | Self::PackageAlreadyExist(_)
+            | Self::PackageNotAllowRemoveVersion { .. }
+            | Self::PackageNotExistInVersion { .. }
+            | Self::AlreadyYanked { .. }
+            | Self::RemoveAllOwners
+            | Self::PackageVersionNotYanked { .. } => StatusCode::BAD_REQUEST,
         }
     }
 }
@@ -70,7 +132,7 @@ impl Database {
         query: &str,
         per_page: Option<usize>,
         deprecated: Option<bool>,
-    ) -> Result<SearchResults, ApiError> {
+    ) -> Result<SearchResults, sqlx::Error> {
         let per_page = match per_page {
             None => 10,
             Some(value) if value > 100 => 100,
@@ -111,7 +173,7 @@ impl Database {
     }
 
     /// Gets whether the database does not contain any package at all
-    pub async fn get_is_empty(&self) -> Result<bool, ApiError> {
+    pub async fn get_is_empty(&self) -> Result<bool, sqlx::Error> {
         Ok(sqlx::query!("SELECT id FROM PackageVersion LIMIT 1")
             .fetch_optional(&mut *self.transaction.borrow().await)
             .await?
@@ -119,14 +181,14 @@ impl Database {
     }
 
     /// Gets the last version number for a package
-    pub async fn get_crate_last_version(&self, package: &str) -> Result<String, ApiError> {
+    pub async fn get_crate_last_version(&self, package: &str) -> Result<String, CratesError> {
         let row = sqlx::query!(
             "SELECT version, description FROM PackageVersion WHERE package = $1 AND yanked = FALSE ORDER BY id DESC LIMIT 1",
             package
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         Ok(row.version)
     }
 
@@ -135,14 +197,14 @@ impl Database {
         &self,
         package: &str,
         versions_in_index: Vec<IndexCrateMetadata>,
-    ) -> Result<CrateInfo, ApiError> {
+    ) -> Result<CrateInfo, CratesError> {
         let row = sqlx::query!(
             "SELECT isDeprecated AS is_deprecated, canRemove AS can_remove, targets, nativeTargets AS nativetargets, capabilities FROM Package WHERE name = $1 LIMIT 1",
             package
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         let is_deprecated = row.is_deprecated;
         let can_remove = row.can_remove;
         let targets = comma_sep_to_vec(&row.targets);
@@ -161,7 +223,13 @@ impl Database {
         let mut versions = Vec::new();
         for index_data in versions_in_index {
             if let Some(row) = rows.iter().find(|row| row.version == index_data.vers) {
-                let uploaded_by = self.get_user_profile(row.uploaded_by).await?;
+                let uploaded_by = self
+                    .get_user_profile(row.uploaded_by)
+                    .await
+                    .map_err(|source| CratesError::UserProfile {
+                        source,
+                        uid: row.uploaded_by,
+                    })?;
                 versions.push(CrateInfoVersion {
                     index: index_data,
                     upload: row.upload,
@@ -208,7 +276,7 @@ impl Database {
     }
 
     /// Publish a crate
-    pub async fn publish_crate_version(&self, uid: i64, package: &CrateUploadData) -> Result<CrateUploadResult, ApiError> {
+    pub async fn publish_crate_version(&self, uid: i64, package: &CrateUploadData) -> Result<CrateUploadResult, CratesError> {
         let warnings = package.metadata.validate()?;
         let lowercase = package.metadata.name.to_ascii_lowercase();
         let row = sqlx::query!(
@@ -219,13 +287,11 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         if let Some(row) = row {
-            return Err(specialize(
-                error_invalid_request(),
-                format!(
-                    "Package {} already exists in version {}, uploaded on {}",
-                    package.metadata.name, package.metadata.vers, row.upload
-                ),
-            ));
+            return Err(CratesError::PackageAlreadyExistInVersion {
+                name: package.metadata.name.clone(),
+                version: package.metadata.vers.clone().into(),
+                dest: row.upload.to_string(),
+            });
         }
         // check whether the package already exists
         let row = sqlx::query!("SELECT name FROM Package WHERE lowercase = $1 LIMIT 1", lowercase)
@@ -234,10 +300,7 @@ impl Database {
         if let Some(row) = row {
             // check this is the same package
             if row.name != lowercase {
-                return Err(specialize(
-                    error_invalid_request(),
-                    format!("A package named {} already exists", row.name),
-                ));
+                return Err(CratesError::PackageAlreadyExist(row.name));
             }
             // check the ownership
             self.check_is_crate_manager(uid, &package.metadata.name).await?;
@@ -276,7 +339,7 @@ impl Database {
     }
 
     /// Completely removes a version from the registry
-    pub async fn remove_crate_version(&self, package: &str, version: &str) -> Result<(), ApiError> {
+    pub async fn remove_crate_version(&self, package: &str, version: &str) -> Result<(), CratesError> {
         // check whether this is allowed
         let can_remove = sqlx::query!(
             "SELECT canRemove AS can_remove FROM Package WHERE lowercase = $1 LIMIT 1",
@@ -286,10 +349,7 @@ impl Database {
         .await?
         .is_some_and(|r| r.can_remove);
         if !can_remove {
-            return Err(specialize(
-                error_invalid_request(),
-                format!("Package {package} does not allow removing versions"),
-            ));
+            return Err(CratesError::PackageNotAllowRemoveVersion { package: package.into() });
         }
         // check version exists
         let row = sqlx::query!(
@@ -300,10 +360,10 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         if row.is_none() {
-            return Err(specialize(
-                error_not_found(),
-                format!("Package {package}, version {version} not found"),
-            ));
+            return Err(CratesError::PackageVersionNotFound {
+                package: package.into(),
+                version: version.into(),
+            });
         }
         sqlx::query!(
             "DELETE FROM PackageVersion WHERE package = $1 AND version = $2",
@@ -324,7 +384,7 @@ impl Database {
     }
 
     /// Yank a crate version
-    pub async fn yank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, ApiError> {
+    pub async fn yank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, CratesError> {
         let row = sqlx::query!(
             "SELECT yanked FROM PackageVersion WHERE package = $1 AND version = $2 LIMIT 1",
             package,
@@ -333,16 +393,16 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         match row {
-            None => Err(specialize(
-                error_invalid_request(),
-                format!("Version {version} of crate {package} does not exist"),
-            )),
+            None => Err(CratesError::PackageNotExistInVersion {
+                package: package.into(),
+                version: version.into(),
+            }),
             Some(row) => {
                 if row.yanked {
-                    Err(specialize(
-                        error_invalid_request(),
-                        format!("Version {version} of crate {package} is already yanked"),
-                    ))
+                    Err(CratesError::AlreadyYanked {
+                        package: package.into(),
+                        version: version.into(),
+                    })
                 } else {
                     sqlx::query!(
                         "UPDATE PackageVersion SET yanked = TRUE WHERE package = $1 AND version = $2",
@@ -358,7 +418,7 @@ impl Database {
     }
 
     /// Unyank a crate version
-    pub async fn unyank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, ApiError> {
+    pub async fn unyank_crate_version(&self, package: &str, version: &str) -> Result<YesNoResult, CratesError> {
         let row = sqlx::query!(
             "SELECT yanked FROM PackageVersion WHERE package = $1 AND version = $2 LIMIT 1",
             package,
@@ -367,10 +427,10 @@ impl Database {
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?;
         match row {
-            None => Err(specialize(
-                error_invalid_request(),
-                format!("Version {version} of crate {package} does not exist"),
-            )),
+            None => Err(CratesError::PackageNotExistInVersion {
+                package: package.into(),
+                version: version.into(),
+            }),
             Some(row) => {
                 if row.yanked {
                     sqlx::query!(
@@ -382,10 +442,10 @@ impl Database {
                     .await?;
                     Ok(YesNoResult::new())
                 } else {
-                    Err(specialize(
-                        error_invalid_request(),
-                        format!("Version {version} of crate {package} is not yanked"),
-                    ))
+                    Err(CratesError::PackageVersionNotYanked {
+                        package: package.into(),
+                        version: version.into(),
+                    })
                 }
             }
         }
@@ -487,7 +547,7 @@ impl Database {
         target: &str,
         is_attempted: bool,
         is_present: bool,
-    ) -> Result<(), ApiError> {
+    ) -> Result<(), sqlx::Error> {
         let is_missing = sqlx::query!(
             "SELECT id FROM PackageVersionDocs WHERE package = $1 AND version = $2 AND target = $3 LIMIT 1",
             package,
@@ -522,7 +582,7 @@ impl Database {
         package: &str,
         version: &str,
         default_target: &str,
-    ) -> Result<Vec<CrateInfoTarget>, ApiError> {
+    ) -> Result<Vec<CrateInfoTarget>, CratesError> {
         self.check_crate_exists(package, version).await?;
 
         let row = sqlx::query!(
@@ -531,7 +591,7 @@ impl Database {
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         let targets = comma_sep_to_vec(&row.targets);
         let native_targets = comma_sep_to_vec(&row.nativetargets);
         let targets = targets
@@ -559,7 +619,7 @@ impl Database {
 
     /// Gets the packages that need to have their dependencies analyzed
     /// Those are the latest version of each crate
-    pub async fn get_unanalyzed_crates(&self, deps_stale_analysis: i64) -> Result<Vec<DepsAnalysisJobSpec>, ApiError> {
+    pub async fn get_unanalyzed_crates(&self, deps_stale_analysis: i64) -> Result<Vec<DepsAnalysisJobSpec>, CratesError> {
         let now = Local::now().naive_local();
         let from = now - Duration::minutes(deps_stale_analysis);
         let heads = self.get_crates_version_heads().await?;
@@ -576,7 +636,7 @@ impl Database {
     }
 
     /// Gets all the packages that are outdated while also being the latest version
-    pub async fn get_crates_outdated_heads(&self) -> Result<Vec<CrateVersion>, ApiError> {
+    pub async fn get_crates_outdated_heads(&self) -> Result<Vec<CrateVersion>, CratesError> {
         let heads = self.get_crates_version_heads().await?;
         Ok(heads
             .into_iter()
@@ -591,7 +651,7 @@ impl Database {
     }
 
     /// Gets all the latest version of crates, filtering out yanked and pre-release versions
-    async fn get_crates_version_heads(&self) -> Result<Vec<DepsAnalysisState>, ApiError> {
+    async fn get_crates_version_heads(&self) -> Result<Vec<DepsAnalysisState>, CratesError> {
         struct Elem {
             semver: Version,
             version: String,
@@ -612,7 +672,10 @@ impl Database {
         while let Some(row) = stream.next().await {
             let row = row?;
             let name = row.package;
-            let semver = row.version.parse::<Version>()?;
+            let semver = row.version.parse::<Version>().map_err(|source| CratesError::ParseVersion {
+                source,
+                version: row.version.clone().into(),
+            })?;
             if semver.pre.is_empty() {
                 // not a pre-release
                 match cache.entry(name.clone()) {
@@ -723,7 +786,7 @@ impl Database {
     }
 
     /// Gets the download statistics for a crate
-    pub async fn get_crate_dl_stats(&self, package: &str) -> Result<DownloadStats, ApiError> {
+    pub async fn get_crate_dl_stats(&self, package: &str) -> Result<DownloadStats, CratesError> {
         let rows = sqlx::query!("SELECT version, downloads FROM PackageVersion WHERE package = $1", package)
             .fetch_all(&mut *self.transaction.borrow().await)
             .await?;
@@ -736,14 +799,14 @@ impl Database {
     }
 
     /// Gets the list of owners for a package
-    pub async fn get_crate_owners(&self, package: &str) -> Result<OwnersQueryResult, ApiError> {
+    pub async fn get_crate_owners(&self, package: &str) -> Result<OwnersQueryResult, CratesError> {
         let users = sqlx::query_as!(RegistryUser, "SELECT RegistryUser.id, isActive AS is_active, email, login, name, roles FROM RegistryUser INNER JOIN PackageOwner ON PackageOwner.owner = RegistryUser.id WHERE package = $1", package)
             .fetch_all(&mut *self.transaction.borrow().await).await?;
         Ok(OwnersQueryResult { users })
     }
 
     /// Add owners to a package
-    pub async fn add_crate_owners(&self, package: &str, new_users: &[String]) -> Result<YesNoMsgResult, ApiError> {
+    pub async fn add_crate_owners(&self, package: &str, new_users: &[String]) -> Result<YesNoMsgResult, CratesError> {
         // get all current owners
         let rows = sqlx::query!("SELECT owner FROM PackageOwner WHERE package = $1", package,)
             .fetch_all(&mut *self.transaction.borrow().await)
@@ -751,7 +814,10 @@ impl Database {
         // add new users
         let mut added = Vec::new();
         for new_user in new_users {
-            let new_uid = self.check_is_user(new_user).await?;
+            let new_uid = self.check_is_user(new_user).await.map_err(|source| CratesError::IsUser {
+                source,
+                email: new_user.into(),
+            })?;
             if rows.iter().all(|r| r.owner != new_uid) {
                 // not already an owner
                 sqlx::query!("INSERT INTO PackageOwner (package, owner) VALUES ($1, $2)", package, new_uid)
@@ -769,7 +835,7 @@ impl Database {
     }
 
     /// Remove owners from a package
-    pub async fn remove_crate_owners(&self, package: &str, old_users: &[String]) -> Result<YesNoResult, ApiError> {
+    pub async fn remove_crate_owners(&self, package: &str, old_users: &[String]) -> Result<YesNoResult, CratesError> {
         // get all current owners
         let rows = sqlx::query!("SELECT owner FROM PackageOwner WHERE package = $1", package,)
             .fetch_all(&mut *self.transaction.borrow().await)
@@ -777,7 +843,10 @@ impl Database {
         let mut current_owners: Vec<i64> = rows.into_iter().map(|r| r.owner).collect();
         // remove old users
         for old_user in old_users {
-            let old_uid = self.check_is_user(old_user).await?;
+            let old_uid = self.check_is_user(old_user).await.map_err(|source| CratesError::IsUser {
+                source,
+                email: old_user.into(),
+            })?;
             let index = current_owners
                 .iter()
                 .enumerate()
@@ -786,7 +855,7 @@ impl Database {
             if let Some(index) = index {
                 if current_owners.len() == 1 {
                     // cannot remove the last one
-                    return Err(specialize(error_invalid_request(), String::from("Cannot remove all owners")));
+                    return Err(CratesError::RemoveAllOwners);
                 }
                 // not already an owner
                 sqlx::query!("DELETE FROM PackageOwner WHERE package = $1 AND owner = $2", package, old_uid)
@@ -799,14 +868,14 @@ impl Database {
     }
 
     /// Gets the targets for a crate
-    pub async fn get_crate_targets(&self, package: &str) -> Result<Vec<CrateInfoTarget>, ApiError> {
+    pub async fn get_crate_targets(&self, package: &str) -> Result<Vec<CrateInfoTarget>, CratesError> {
         let row = sqlx::query!(
             "SELECT targets, nativeTargets AS nativetargets FROM Package WHERE name = $1 LIMIT 1",
             package
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
         .await?
-        .ok_or_else(error_not_found)?;
+        .ok_or_else(|| CratesError::PackageNotFound { package: package.into() })?;
         let targets = comma_sep_to_vec(&row.targets);
         let native_targets = comma_sep_to_vec(&row.nativetargets);
         Ok(targets
@@ -819,7 +888,11 @@ impl Database {
     }
 
     /// Sets the targets for a crate
-    pub async fn set_crate_targets(&self, package: &str, targets: &[CrateInfoTarget]) -> Result<Vec<DocGenJobSpec>, ApiError> {
+    pub async fn set_crate_targets(
+        &self,
+        package: &str,
+        targets: &[CrateInfoTarget],
+    ) -> Result<Vec<DocGenJobSpec>, CratesError> {
         let old_targets = self.get_crate_targets(package).await?;
         let added_targets = targets
             .iter()

--- a/src/services/database/stats.rs
+++ b/src/services/database/stats.rs
@@ -10,7 +10,6 @@ use thiserror::Error;
 use super::Database;
 use crate::model::CrateVersion;
 use crate::model::stats::GlobalStats;
-use crate::utils::apierror::AsStatusCode;
 
 #[derive(Debug, Error)]
 pub enum CratesStatsError {
@@ -26,7 +25,6 @@ pub enum CratesStatsError {
     #[error("error during execution of request to get info of `last updated` crates")]
     LastUpdated(#[source] sqlx::Error),
 }
-impl AsStatusCode for CratesStatsError {}
 
 impl Database {
     /// Gets the global statistics for the registry

--- a/src/services/database/stats.rs
+++ b/src/services/database/stats.rs
@@ -5,21 +5,41 @@
 //! Service for persisting information in the database
 //! API related to statistics
 
+use thiserror::Error;
+
 use super::Database;
 use crate::model::CrateVersion;
 use crate::model::stats::GlobalStats;
-use crate::utils::apierror::ApiError;
+use crate::utils::apierror::AsStatusCode;
+
+#[derive(Debug, Error)]
+pub enum CratesStatsError {
+    #[error("error during execution of request to count crates")]
+    CountCrates(#[source] sqlx::Error),
+    #[error("error during execution of request to count downloads")]
+    CountDownload(#[source] sqlx::Error),
+
+    #[error("error during execution of request to get info of `newest` crates")]
+    NewestCrates(#[source] sqlx::Error),
+    #[error("error during execution of request to get info of `most downloaded` crates")]
+    MostDownloaded(#[source] sqlx::Error),
+    #[error("error during execution of request to get info of `last updated` crates")]
+    LastUpdated(#[source] sqlx::Error),
+}
+impl AsStatusCode for CratesStatsError {}
 
 impl Database {
     /// Gets the global statistics for the registry
-    pub async fn get_crates_stats(&self) -> Result<GlobalStats, ApiError> {
+    pub async fn get_crates_stats(&self) -> Result<GlobalStats, CratesStatsError> {
         let total_crates = sqlx::query!("SELECT COUNT(name) AS total_crates FROM Package")
             .fetch_one(&mut *self.transaction.borrow().await)
-            .await?
+            .await
+            .map_err(CratesStatsError::CountCrates)?
             .total_crates;
         let total_downloads = sqlx::query!("SELECT SUM(downloadCount) AS total_downloads FROM PackageVersion")
             .fetch_one(&mut *self.transaction.borrow().await)
-            .await?
+            .await
+            .map_err(CratesStatsError::CountDownload)?
             .total_downloads
             .unwrap_or_default();
 
@@ -31,7 +51,8 @@ impl Database {
             LIMIT 10"
         )
         .fetch_all(&mut *self.transaction.borrow().await)
-        .await?;
+        .await
+        .map_err(CratesStatsError::NewestCrates)?;
         let crates_newest = rows
             .into_iter()
             .map(|row| CrateVersion {
@@ -48,7 +69,8 @@ impl Database {
             LIMIT 10"
         )
         .fetch_all(&mut *self.transaction.borrow().await)
-        .await?;
+        .await
+        .map_err(CratesStatsError::MostDownloaded)?;
         let crates_most_downloaded = rows
             .into_iter()
             .map(|row| CrateVersion {
@@ -64,7 +86,8 @@ impl Database {
             LIMIT 10"
         )
         .fetch_all(&mut *self.transaction.borrow().await)
-        .await?;
+        .await
+        .map_err(CratesStatsError::LastUpdated)?;
         let crates_last_updated = rows
             .into_iter()
             .map(|row| CrateVersion {

--- a/src/services/database/users.rs
+++ b/src/services/database/users.rs
@@ -395,7 +395,7 @@ impl Database {
     }
 
     /// Updates the last usage of a token
-    pub async fn update_token_last_usage(&self, event: &TokenUsage) -> Result<(), ApiError> {
+    pub async fn update_token_last_usage(&self, event: &TokenUsage) -> Result<(), sqlx::Error> {
         if event.kind == TokenKind::User {
             sqlx::query!(
                 "UPDATE RegistryUserToken SET lastUsed = $2 WHERE id = $1",

--- a/src/services/database/users.rs
+++ b/src/services/database/users.rs
@@ -20,7 +20,7 @@ use crate::model::auth::{
 use crate::model::cargo::RegistryUser;
 use crate::model::config::Configuration;
 use crate::model::namegen::generate_name;
-use crate::utils::apierror::{ApiError, AsStatusCode, error_forbidden, error_not_found, specialize};
+use crate::utils::apierror::AsStatusCode;
 use crate::utils::token::{check_hash, generate_token, hash_token};
 
 #[derive(Debug, Error)]
@@ -66,18 +66,54 @@ pub enum UpdateUserError {
 
     #[error("user can't update user")]
     Authentication(#[from] AuthenticationError),
+
+    #[error("cannot self deactivate")]
+    SelfDeactivate,
+
+    #[error("failed to execute request for activate user")]
+    ActiveUserSql {
+        #[source]
+        source: sqlx::Error,
+        target: String,
+    },
+
+    #[error("failed to execute request to select user corresponding an email")]
+    SqlSelectUserByEmail(#[source] sqlx::Error),
+
+    #[error("user for `{0}` not found")]
+    UserEmailNotFound(String),
+
+    #[error("cannot delete self")]
+    CannotDeleteSelf,
+
+    #[error("failed to execute request to remove user token")]
+    SqlRemoveUserToken(#[source] sqlx::Error),
+
+    #[error("failed to execute request to remove user as package owner")]
+    SqlRemoveFromPackageOwner(#[source] sqlx::Error),
+
+    #[error("failed to execute request to remove user")]
+    SqlRemoveUser(#[source] sqlx::Error),
 }
 
 impl AsStatusCode for UpdateUserError {
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::SqlLoginAndRoles(_) | Self::CountUserForLogin(_) | Self::UpdateUserSqlx(_) | Self::Authentication(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            Self::SqlLoginAndRoles(_)
+            | Self::CountUserForLogin(_)
+            | Self::UpdateUserSqlx(_)
+            | Self::Authentication(_)
+            | Self::SqlSelectUserByEmail(_)
+            | Self::ActiveUserSql { .. }
+            | Self::SqlRemoveUserToken(_)
+            | Self::SqlRemoveFromPackageOwner(_)
+            | Self::SqlRemoveUser(_) => StatusCode::INTERNAL_SERVER_ERROR,
 
-            Self::AdminCantRemoveThemselves | Self::OnlyAdminCanChangeRoles => StatusCode::FORBIDDEN,
+            Self::AdminCantRemoveThemselves | Self::OnlyAdminCanChangeRoles | Self::SelfDeactivate | Self::CannotDeleteSelf => {
+                StatusCode::FORBIDDEN
+            }
             Self::LoginCannotBeEmpty => StatusCode::BAD_REQUEST,
-            Self::UserNotFound { .. } => StatusCode::NOT_FOUND,
+            Self::UserNotFound { .. } | Self::UserEmailNotFound(_) => StatusCode::NOT_FOUND,
 
             Self::LoginNotAvailable { .. } => StatusCode::CONFLICT,
         }
@@ -355,15 +391,19 @@ impl Database {
     }
 
     /// Attempts to deactivate a user
-    pub async fn deactivate_user(&self, principal_uid: i64, target: &str) -> Result<(), ApiError> {
+    pub async fn deactivate_user(&self, principal_uid: i64, target: &str) -> Result<(), UpdateUserError> {
         let target_uid = self.check_is_user(target).await?;
         if principal_uid == target_uid {
             // cannot deactivate self
-            return Err(specialize(error_forbidden(), String::from("cannot self deactivate")));
+            return Err(UpdateUserError::SelfDeactivate);
         }
         sqlx::query!("UPDATE RegistryUser SET isActive = FALSE WHERE id = $1", target_uid)
             .execute(&mut *self.transaction.borrow().await)
-            .await?;
+            .await
+            .map_err(|source| UpdateUserError::ActiveUserSql {
+                source,
+                target: target.into(),
+            })?;
         Ok(())
     }
 
@@ -376,24 +416,28 @@ impl Database {
     }
 
     /// Attempts to delete a user
-    pub async fn delete_user(&self, principal_uid: i64, target: &str) -> Result<(), ApiError> {
+    pub async fn delete_user(&self, principal_uid: i64, target: &str) -> Result<(), UpdateUserError> {
         let target_uid = sqlx::query!("SELECT id FROM RegistryUser WHERE email = $1", target)
             .fetch_optional(&mut *self.transaction.borrow().await)
-            .await?
-            .ok_or_else(error_not_found)?
+            .await
+            .map_err(UpdateUserError::SqlSelectUserByEmail)?
+            .ok_or_else(|| UpdateUserError::UserEmailNotFound(target.into()))?
             .id;
         if principal_uid == target_uid {
-            return Err(specialize(error_forbidden(), String::from("cannot delete self")));
+            return Err(UpdateUserError::CannotDeleteSelf);
         }
         sqlx::query!("DELETE FROM RegistryUserToken WHERE user = $1", target_uid)
             .execute(&mut *self.transaction.borrow().await)
-            .await?;
+            .await
+            .map_err(UpdateUserError::SqlRemoveUserToken)?;
         sqlx::query!("DELETE FROM PackageOwner WHERE owner = $1", target_uid)
             .execute(&mut *self.transaction.borrow().await)
-            .await?;
+            .await
+            .map_err(UpdateUserError::SqlRemoveFromPackageOwner)?;
         sqlx::query!("DELETE FROM RegistryUser WHERE id = $1", target_uid)
             .execute(&mut *self.transaction.borrow().await)
-            .await?;
+            .await
+            .map_err(UpdateUserError::SqlRemoveUser)?;
         Ok(())
     }
 

--- a/src/services/database/users.rs
+++ b/src/services/database/users.rs
@@ -8,6 +8,7 @@
 use std::future::Future;
 
 use chrono::Local;
+use thiserror::Error;
 
 use super::Database;
 use crate::model::auth::{
@@ -18,21 +19,38 @@ use crate::model::cargo::RegistryUser;
 use crate::model::config::Configuration;
 use crate::model::namegen::generate_name;
 use crate::utils::apierror::{
-    ApiError, error_conflict, error_forbidden, error_invalid_request, error_not_found, error_unauthorized, specialize,
+    ApiError, AsStatusCode, error_conflict, error_forbidden, error_invalid_request, error_not_found, error_unauthorized,
+    specialize,
 };
 use crate::utils::token::{check_hash, generate_token, hash_token};
 
+#[derive(Debug, Error)]
+pub enum UserError {
+    #[error("failed to execute sql request to get user profile for `{uid}`")]
+    SqlxGetUserProfile {
+        #[source]
+        source: sqlx::Error,
+        uid: i64,
+    },
+
+    #[error("user with uid `{uid}` not found")]
+    UserNotFound { uid: i64 },
+}
+
+impl AsStatusCode for UserError {}
+
 impl Database {
     /// Retrieves a user profile
-    pub async fn get_user_profile(&self, uid: i64) -> Result<RegistryUser, ApiError> {
+    pub async fn get_user_profile(&self, uid: i64) -> Result<RegistryUser, UserError> {
         let maybe_row = sqlx::query_as!(
             RegistryUser,
             "SELECT id, isActive AS is_active, email, login, name, roles FROM RegistryUser WHERE id = $1",
             uid
         )
         .fetch_optional(&mut *self.transaction.borrow().await)
-        .await?;
-        maybe_row.ok_or_else(error_not_found)
+        .await
+        .map_err(|source| UserError::SqlxGetUserProfile { source, uid })?;
+        maybe_row.ok_or(UserError::UserNotFound { uid })
     }
 
     /// Attempts to login using an OAuth code

--- a/src/services/database/users.rs
+++ b/src/services/database/users.rs
@@ -20,9 +20,7 @@ use crate::model::auth::{
 use crate::model::cargo::RegistryUser;
 use crate::model::config::Configuration;
 use crate::model::namegen::generate_name;
-use crate::utils::apierror::{
-    ApiError, AsStatusCode, error_conflict, error_forbidden, error_invalid_request, error_not_found, specialize,
-};
+use crate::utils::apierror::{ApiError, AsStatusCode, error_forbidden, error_not_found, specialize};
 use crate::utils::token::{check_hash, generate_token, hash_token};
 
 #[derive(Debug, Error)]
@@ -39,6 +37,52 @@ pub enum UserError {
 }
 
 impl AsStatusCode for UserError {}
+
+#[derive(Debug, Error)]
+pub enum UpdateUserError {
+    #[error("failed to execute request for get login and roles on DB")]
+    SqlLoginAndRoles(#[source] sqlx::Error),
+
+    #[error("user with id `{uid}`not found")]
+    UserNotFound { uid: i64 },
+
+    #[error("only admins can change roles")]
+    OnlyAdminCanChangeRoles,
+
+    #[error("admins cannot remove themselves")]
+    AdminCantRemoveThemselves,
+
+    #[error("login cannot be empty")]
+    LoginCannotBeEmpty,
+
+    #[error("failed to execute request for count RegistryUser for login")]
+    CountUserForLogin(#[source] sqlx::Error),
+
+    #[error("the specified login `{login}` is not found in db")]
+    LoginNotAvailable { login: String },
+
+    #[error("failed to execute db request to update user")]
+    UpdateUserSqlx(#[source] sqlx::Error),
+
+    #[error("user can't update user")]
+    Authentication(#[from] AuthenticationError),
+}
+
+impl AsStatusCode for UpdateUserError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::SqlLoginAndRoles(_) | Self::CountUserForLogin(_) | Self::UpdateUserSqlx(_) | Self::Authentication(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+
+            Self::AdminCantRemoveThemselves | Self::OnlyAdminCanChangeRoles => StatusCode::FORBIDDEN,
+            Self::LoginCannotBeEmpty => StatusCode::BAD_REQUEST,
+            Self::UserNotFound { .. } => StatusCode::NOT_FOUND,
+
+            Self::LoginNotAvailable { .. } => StatusCode::CONFLICT,
+        }
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum OAuthLoginError {
@@ -265,35 +309,36 @@ impl Database {
         principal_uid: i64,
         target: &RegistryUser,
         can_admin: bool,
-    ) -> Result<RegistryUser, ApiError> {
+    ) -> Result<RegistryUser, UpdateUserError> {
         let row = sqlx::query!("SELECT login, roles FROM RegistryUser WHERE id = $1 LIMIT 1", target.id)
             .fetch_optional(&mut *self.transaction.borrow().await)
-            .await?
-            .ok_or_else(error_not_found)?;
+            .await
+            .map_err(UpdateUserError::SqlLoginAndRoles)?
+            .ok_or_else(|| UpdateUserError::UserNotFound { uid: target.id })?;
         let old_roles = row.roles;
         if !can_admin && target.roles != old_roles {
             // not admin and changing roles
-            return Err(specialize(error_forbidden(), String::from("only admins can change roles")));
+            return Err(UpdateUserError::OnlyAdminCanChangeRoles);
         }
         if can_admin && target.id == principal_uid && target.roles.split(',').all(|role| role.trim() != ROLE_ADMIN) {
             // admin and removing admin role from self
-            return Err(specialize(error_forbidden(), String::from("admins cannot remove themselves")));
+            return Err(UpdateUserError::AdminCantRemoveThemselves);
         }
         if target.login.is_empty() {
-            return Err(specialize(error_invalid_request(), String::from("login cannot be empty")));
+            return Err(UpdateUserError::LoginCannotBeEmpty);
         }
         if row.login != target.login {
             // check that the new login is available
             if sqlx::query!("SELECT COUNT(id) AS count FROM RegistryUser WHERE login = $1", target.login)
                 .fetch_one(&mut *self.transaction.borrow().await)
-                .await?
+                .await
+                .map_err(UpdateUserError::CountUserForLogin)?
                 .count
                 != 0
             {
-                return Err(specialize(
-                    error_conflict(),
-                    String::from("the specified login is not available"),
-                ));
+                return Err(UpdateUserError::LoginNotAvailable {
+                    login: target.login.clone(),
+                });
             }
         }
         sqlx::query!(
@@ -304,7 +349,8 @@ impl Database {
             target.roles
         )
         .execute(&mut *self.transaction.borrow().await)
-        .await?;
+        .await
+        .map_err(UpdateUserError::UpdateUserSqlx)?;
         Ok(target.clone())
     }
 

--- a/src/services/deps.rs
+++ b/src/services/deps.rs
@@ -390,7 +390,7 @@ impl DepsCheckerImpl {
             }
         } else {
             // same registry, lookup in internal index
-            self.service_index.get_crate_data(name).await
+            self.service_index.get_crate_data(name).await.map_err(ApiError::from)
         }
     }
 

--- a/src/services/docs.rs
+++ b/src/services/docs.rs
@@ -24,7 +24,7 @@ use crate::model::CHANNEL_NIGHTLY;
 use crate::model::config::Configuration;
 use crate::model::docs::{DocGenEvent, DocGenJob, DocGenJobSpec, DocGenJobState, DocGenJobUpdate, DocGenTrigger};
 use crate::model::worker::{JobIdentifier, JobSpecification, JobUpdate, WorkersManager};
-use crate::services::database::{DbReadError, db_transaction_read, db_transaction_write};
+use crate::services::database::{DbReadError, DbWriteError, db_transaction_read, db_transaction_write};
 use crate::services::storage::Storage;
 use crate::utils::FaillibleFuture;
 use crate::utils::apierror::{ApiError, error_backend_failure, error_invalid_request, specialize};
@@ -40,7 +40,11 @@ pub trait DocsGenerator {
     fn get_job_log(&self, job_id: i64) -> FaillibleFuture<'_, String>;
 
     /// Queues a job for documentation generation
-    fn queue<'a>(&'a self, spec: &'a DocGenJobSpec, trigger: &'a DocGenTrigger) -> FaillibleFuture<'a, DocGenJob>;
+    fn queue<'a>(
+        &'a self,
+        spec: &'a DocGenJobSpec,
+        trigger: &'a DocGenTrigger,
+    ) -> BoxFuture<'a, Result<DocGenJob, DbWriteError>>;
 
     /// Adds a listener to job updates
     fn add_listener(&self, listener: Sender<DocGenEvent>) -> FaillibleFuture<'_, ()>;
@@ -110,7 +114,11 @@ impl DocsGenerator for DocsGeneratorImpl {
     }
 
     /// Queues a job for documentation generation
-    fn queue<'a>(&'a self, spec: &'a DocGenJobSpec, trigger: &'a DocGenTrigger) -> FaillibleFuture<'a, DocGenJob> {
+    fn queue<'a>(
+        &'a self,
+        spec: &'a DocGenJobSpec,
+        trigger: &'a DocGenTrigger,
+    ) -> BoxFuture<'a, Result<DocGenJob, DbWriteError>> {
         Box::pin(async move {
             let job = db_transaction_write(&self.service_db_pool, "create_docgen_job", |database| async move {
                 database.create_docgen_job(spec, trigger).await
@@ -150,7 +158,7 @@ impl DocsGeneratorImpl {
     }
 
     /// Update a job
-    async fn update_job(&self, job: &DocGenJob, state: DocGenJobState, log: Option<&str>) -> Result<(), ApiError> {
+    async fn update_job(&self, job: &DocGenJob, state: DocGenJobState, log: Option<&str>) -> Result<(), DbWriteError> {
         db_transaction_write(&self.service_db_pool, "update_job", |database| async move {
             database.update_docgen_job(job.id, state).await?;
             database

--- a/src/services/docs.rs
+++ b/src/services/docs.rs
@@ -88,10 +88,9 @@ impl DocsGenerator for DocsGeneratorImpl {
     /// Gets all the jobs
     fn get_jobs(&self) -> FaillibleFuture<'_, Vec<DocGenJob>> {
         Box::pin(async move {
-            db_transaction_read(
-                &self.service_db_pool,
-                |database| async move { database.get_docgen_jobs().await },
-            )
+            db_transaction_read(&self.service_db_pool, |database| async move {
+                database.get_docgen_jobs().await.map_err(ApiError::from)
+            })
             .await
         })
     }
@@ -100,7 +99,7 @@ impl DocsGenerator for DocsGeneratorImpl {
     fn get_job_log(&self, job_id: i64) -> FaillibleFuture<'_, String> {
         Box::pin(async move {
             let job = db_transaction_read(&self.service_db_pool, |database| async move {
-                database.get_docgen_job(job_id).await
+                database.get_docgen_job(job_id).await.map_err(ApiError::from)
             })
             .await?;
             let data = self.service_storage.download_doc_file(&job_log_location(&job)).await?;
@@ -180,7 +179,7 @@ impl DocsGeneratorImpl {
     /// Gets the next job, if any
     async fn get_next_job(&self) -> Result<Option<DocGenJob>, ApiError> {
         db_transaction_read(&self.service_db_pool, |database| async move {
-            database.get_next_docgen_job().await
+            database.get_next_docgen_job().await.map_err(ApiError::from)
         })
         .await
     }

--- a/src/services/docs.rs
+++ b/src/services/docs.rs
@@ -112,7 +112,7 @@ impl DocsGenerator for DocsGeneratorImpl {
     fn queue<'a>(&'a self, spec: &'a DocGenJobSpec, trigger: &'a DocGenTrigger) -> FaillibleFuture<'a, DocGenJob> {
         Box::pin(async move {
             let job = db_transaction_write(&self.service_db_pool, "create_docgen_job", |database| async move {
-                database.create_docgen_job(spec, trigger).await
+                database.create_docgen_job(spec, trigger).await.map_err(ApiError::from)
             })
             .await?;
             self.send_event(DocGenEvent::Queued(Box::new(job.clone()))).await;

--- a/src/services/docs.rs
+++ b/src/services/docs.rs
@@ -115,7 +115,7 @@ impl DocsGenerator for DocsGeneratorImpl {
                 database.create_docgen_job(spec, trigger).await
             })
             .await?;
-            self.send_event(DocGenEvent::Queued(Box::new(job.clone()))).await?;
+            self.send_event(DocGenEvent::Queued(Box::new(job.clone()))).await;
             Ok(job)
         })
     }
@@ -132,7 +132,7 @@ impl DocsGenerator for DocsGeneratorImpl {
 impl DocsGeneratorImpl {
     /// Send an event to listeners
     #[expect(clippy::significant_drop_tightening)]
-    async fn send_event(&self, event: DocGenEvent) -> Result<(), ApiError> {
+    async fn send_event(&self, event: DocGenEvent) {
         let mut listeners = self.listeners.lock().await;
         let mut index = if listeners.is_empty() {
             None
@@ -146,7 +146,6 @@ impl DocsGeneratorImpl {
             }
             index = if i == 0 { None } else { Some(i - 1) };
         }
-        Ok(())
     }
 
     /// Update a job
@@ -174,7 +173,7 @@ impl DocsGeneratorImpl {
             last_update: now,
             log: log.map(str::to_string),
         }))
-        .await?;
+        .await;
         Ok(())
     }
 

--- a/src/services/docs.rs
+++ b/src/services/docs.rs
@@ -112,7 +112,7 @@ impl DocsGenerator for DocsGeneratorImpl {
     fn queue<'a>(&'a self, spec: &'a DocGenJobSpec, trigger: &'a DocGenTrigger) -> FaillibleFuture<'a, DocGenJob> {
         Box::pin(async move {
             let job = db_transaction_write(&self.service_db_pool, "create_docgen_job", |database| async move {
-                database.create_docgen_job(spec, trigger).await.map_err(ApiError::from)
+                database.create_docgen_job(spec, trigger).await
             })
             .await?;
             self.send_event(DocGenEvent::Queued(Box::new(job.clone()))).await;
@@ -160,8 +160,7 @@ impl DocsGeneratorImpl {
                     state != DocGenJobState::Queued,
                     state == DocGenJobState::Success,
                 )
-                .await?;
-            Ok::<_, ApiError>(())
+                .await
         })
         .await?;
 

--- a/src/services/docs.rs
+++ b/src/services/docs.rs
@@ -88,9 +88,10 @@ impl DocsGenerator for DocsGeneratorImpl {
     /// Gets all the jobs
     fn get_jobs(&self) -> FaillibleFuture<'_, Vec<DocGenJob>> {
         Box::pin(async move {
-            db_transaction_read(&self.service_db_pool, |database| async move {
-                database.get_docgen_jobs().await.map_err(ApiError::from)
-            })
+            db_transaction_read(
+                &self.service_db_pool,
+                |database| async move { database.get_docgen_jobs().await },
+            )
             .await
         })
     }
@@ -99,7 +100,7 @@ impl DocsGenerator for DocsGeneratorImpl {
     fn get_job_log(&self, job_id: i64) -> FaillibleFuture<'_, String> {
         Box::pin(async move {
             let job = db_transaction_read(&self.service_db_pool, |database| async move {
-                database.get_docgen_job(job_id).await.map_err(ApiError::from)
+                database.get_docgen_job(job_id).await
             })
             .await?;
             let data = self.service_storage.download_doc_file(&job_log_location(&job)).await?;
@@ -179,7 +180,7 @@ impl DocsGeneratorImpl {
     /// Gets the next job, if any
     async fn get_next_job(&self) -> Result<Option<DocGenJob>, ApiError> {
         db_transaction_read(&self.service_db_pool, |database| async move {
-            database.get_next_docgen_job().await.map_err(ApiError::from)
+            database.get_next_docgen_job().await
         })
         .await
     }

--- a/src/services/index/git.rs
+++ b/src/services/index/git.rs
@@ -7,15 +7,89 @@
 use std::path::{Path, PathBuf};
 
 use log::{error, info};
+use thiserror::Error;
 use tokio::fs::{File, OpenOptions, create_dir_all};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 
 use super::{Index, build_package_file_path};
 use crate::model::cargo::IndexCrateMetadata;
 use crate::model::config::IndexConfig;
-use crate::utils::apierror::{ApiError, error_backend_failure, error_not_found, specialize};
-use crate::utils::{FaillibleFuture, execute_at_location, execute_git};
+use crate::utils::apierror::{ApiError, AsStatusCode, error_not_found, specialize};
+use crate::utils::{CommandError, FaillibleFuture, execute_at_location, execute_git};
+
+#[derive(Debug, Error)]
+pub enum GitIndexError {
+    #[error("missing key file: '{key_filename}'")]
+    MissingKeyFile { key_filename: PathBuf },
+
+    #[error("fail to create dir : '{location}'")]
+    CreateDirAll {
+        #[source]
+        source: io::Error,
+        location: PathBuf,
+    },
+
+    #[error("fail to read dir : '{location}'")]
+    ReadDir {
+        #[source]
+        source: io::Error,
+        location: PathBuf,
+    },
+
+    #[error("error during read first entry in : '{location}'")]
+    ReadNextEntry {
+        #[source]
+        source: io::Error,
+        location: PathBuf,
+    },
+
+    #[error("failed init repository ad '{location}'")]
+    CommandInit {
+        #[source]
+        src: CommandError,
+        location: PathBuf,
+    },
+
+    #[error("failed to clone '{remote}'")]
+    CommandClone {
+        #[source]
+        source: CommandError,
+        remote: String,
+    },
+
+    #[error("failed to pull origin master")]
+    CommandPull(#[source] CommandError),
+
+    #[error("failed to configure user")]
+    ConfigureUser(#[source] CommandError),
+
+    #[error("failed to add remote origin '{remote}' user")]
+    AddRemoteOrigin {
+        #[source]
+        src: CommandError,
+        remote: String,
+    },
+
+    #[error("failed to add files to git repository index")]
+    CommandAdd(#[source] CommandError),
+
+    #[error("failed to commit indexed files in git ")]
+    CommandCommit(#[source] CommandError),
+
+    #[error("failed to update server info of git repository")]
+    UpdateServerInfo(#[source] CommandError),
+
+    #[error("failed to push origin master")]
+    PushOriginMaster(#[source] CommandError),
+
+    #[error("fail to serialize index public config")]
+    PublicConfigSerialization(#[source] serde_json::Error),
+
+    #[error("fail to write git index public config")]
+    WritePublicConfig(#[source] io::Error),
+}
+impl AsStatusCode for GitIndexError {}
 
 /// Manages the index on git
 pub struct GitIndex {
@@ -24,7 +98,7 @@ pub struct GitIndex {
 
 impl GitIndex {
     /// When the application is launched
-    pub async fn new(config: IndexConfig, expect_empty: bool) -> Result<Self, ApiError> {
+    pub async fn new(config: IndexConfig, expect_empty: bool) -> Result<Self, GitIndexError> {
         let inner = GitIndexImpl::new(config, expect_empty).await?;
         Ok(Self {
             inner: Mutex::new(inner),
@@ -66,7 +140,7 @@ struct GitIndexImpl {
 
 impl GitIndexImpl {
     /// When the application is launched
-    async fn new(config: IndexConfig, expect_empty: bool) -> Result<Self, ApiError> {
+    async fn new(config: IndexConfig, expect_empty: bool) -> Result<Self, GitIndexError> {
         let index = Self { config };
 
         // check for the SSH key
@@ -75,41 +149,58 @@ impl GitIndexImpl {
             key_filename.push(".ssh");
             key_filename.push(file_name);
             if !key_filename.exists() {
-                return Err(specialize(
-                    error_backend_failure(),
-                    format!("Missing key file: {}", key_filename.display()),
-                ));
+                return Err(GitIndexError::MissingKeyFile { key_filename });
             }
         }
 
         // check that the git folder exists
         let location = PathBuf::from(&index.config.location);
         if !location.exists() {
-            tokio::fs::create_dir_all(&location).await?;
+            tokio::fs::create_dir_all(&location)
+                .await
+                .map_err(|source| GitIndexError::CreateDirAll {
+                    source,
+                    location: location.clone(),
+                })?;
         }
 
-        let mut content = tokio::fs::read_dir(&location).await?;
-        if content.next_entry().await?.is_none() {
+        let mut content = tokio::fs::read_dir(&location)
+            .await
+            .map_err(|source| GitIndexError::ReadDir {
+                source,
+                location: location.clone(),
+            })?;
+        if content
+            .next_entry()
+            .await
+            .map_err(|source| GitIndexError::ReadNextEntry {
+                source,
+                location: location.clone(),
+            })?
+            .is_none()
+        {
             // the folder is empty
             info!("index: initializing on empty index");
             index.initialize_on_empty(&location, expect_empty).await?;
         } else if index.config.remote_origin.is_some() {
             // attempt to pull changes
             info!("index: pulling changes from origin");
-            execute_git(&location, &["pull", "origin", "master"]).await?;
+            execute_git(&location, &["pull", "origin", "master"])
+                .await
+                .map_err(GitIndexError::CommandPull)?;
         }
-        index.configure_user(&location).await?;
+        index.configure_user(&location).await.map_err(GitIndexError::ConfigureUser)?;
         Ok(index)
     }
 
     /// Initializes the index at the specified location when found empty
-    async fn initialize_on_empty(&self, location: &Path, expect_empty: bool) -> Result<(), ApiError> {
+    async fn initialize_on_empty(&self, location: &Path, expect_empty: bool) -> Result<(), GitIndexError> {
         if let Some(remote_origin) = &self.config.remote_origin {
             // attempts to clone
             info!("index: cloning from {remote_origin}");
             match execute_git(location, &["clone", remote_origin, "."]).await {
                 Ok(()) => {
-                    self.configure_user(location).await?;
+                    self.configure_user(location).await.map_err(GitIndexError::ConfigureUser)?;
                     // cloned and (re-)configured the git user
                     return Ok(());
                 }
@@ -118,57 +209,73 @@ impl GitIndexImpl {
                     if expect_empty {
                         // this could be normal if we expected an empty index
                         // fallback to creating an empty index
-                        info!(
-                            "index: clone failed on empty database, this could be normal: {}",
-                            error.details.as_ref().unwrap()
-                        );
+                        info!("index: clone failed on empty database, this could be normal: {error}");
                     } else {
                         // we expected to successfully clone because the database is not empty
                         // so we have some packages in the database, but not in the index ... not good
-                        error!("index: clone unexpectedly failed: {}", error.details.as_ref().unwrap());
-                        return Err(error);
+                        error!("index: clone unexpectedly failed: {error}");
+                        return Err(GitIndexError::CommandClone {
+                            source: error,
+                            remote: remote_origin.clone(),
+                        });
                     }
                 }
             }
         }
 
         // initializes an empty index
-        self.initialize_new_index(location).await?;
-        Ok(())
+        self.initialize_new_index(location).await
     }
 
     /// Initializes an empty index at the specified location
-    async fn initialize_new_index(&self, location: &Path) -> Result<(), ApiError> {
+    async fn initialize_new_index(&self, location: &Path) -> Result<(), GitIndexError> {
         // initialise an empty repo
         info!("index: initializing empty index");
-        execute_git(location, &["init"]).await?;
-        self.configure_user(location).await?;
+        execute_git(location, &["init"])
+            .await
+            .map_err(|src| GitIndexError::CommandInit {
+                src,
+                location: location.to_path_buf(),
+            })?;
+        self.configure_user(location).await.map_err(GitIndexError::ConfigureUser)?;
         if let Some(remote_origin) = &self.config.remote_origin {
-            execute_git(location, &["remote", "add", "origin", remote_origin]).await?;
+            execute_git(location, &["remote", "add", "origin", remote_origin])
+                .await
+                .map_err(|src| GitIndexError::AddRemoteOrigin {
+                    src,
+                    remote: remote_origin.clone(),
+                })?;
         }
         // write the index configuration
         {
-            let index_config = serde_json::to_vec(&self.config.public)?;
+            let index_config = serde_json::to_vec(&self.config.public).map_err(GitIndexError::PublicConfigSerialization)?;
             let mut file_name = location.to_path_buf();
             file_name.push("config.json");
-            let mut file = File::create(&file_name).await?;
-            file.write_all(&index_config).await?;
-            file.flush().await?;
-            file.sync_all().await?;
+            write_file(&file_name, &index_config)
+                .await
+                .map_err(GitIndexError::WritePublicConfig)?;
         }
         // commit the configuration
-        execute_git(location, &["add", "."]).await?;
-        execute_git(location, &["commit", "-m", "Add initial configuration"]).await?;
-        execute_git(location, &["update-server-info"]).await?;
+        execute_git(location, &["add", "."])
+            .await
+            .map_err(GitIndexError::CommandAdd)?;
+        execute_git(location, &["commit", "-m", "Add initial configuration"])
+            .await
+            .map_err(GitIndexError::CommandCommit)?;
+        execute_git(location, &["update-server-info"])
+            .await
+            .map_err(GitIndexError::UpdateServerInfo)?;
         if let (Some(remote_origin), true) = (self.config.remote_origin.as_ref(), self.config.remote_push_changes) {
             info!("index: pushing to {remote_origin}");
-            execute_git(location, &["push", "origin", "master"]).await?;
+            execute_git(location, &["push", "origin", "master"])
+                .await
+                .map_err(GitIndexError::PushOriginMaster)?;
         }
         Ok(())
     }
 
     /// Configures the git user
-    async fn configure_user(&self, location: &Path) -> Result<(), ApiError> {
+    async fn configure_user(&self, location: &Path) -> Result<(), CommandError> {
         execute_git(location, &["config", "user.name", &self.config.user_name]).await?;
         execute_git(location, &["config", "user.email", &self.config.user_email]).await?;
         Ok(())
@@ -200,7 +307,9 @@ impl GitIndexImpl {
     /// Gets the response for an upload pack request
     async fn get_upload_pack_for(&self, input: &[u8]) -> Result<Vec<u8>, ApiError> {
         let location = PathBuf::from(&self.config.location);
-        execute_at_location(&location, "git-upload-pack", &["--stateless-rpc", ".git"], input).await
+        execute_at_location(&location, "git-upload-pack", &["--stateless-rpc", ".git"], input)
+            .await
+            .map_err(ApiError::from)
     }
 
     /// Publish a new version for a crate
@@ -286,4 +395,11 @@ impl GitIndexImpl {
         }
         Ok(results)
     }
+}
+
+async fn write_file(path: impl AsRef<Path>, index_config: &[u8]) -> Result<(), io::Error> {
+    let mut file = File::create(path).await?;
+    file.write_all(index_config).await?;
+    file.flush().await?;
+    file.sync_all().await
 }

--- a/src/services/index/mod.rs
+++ b/src/services/index/mod.rs
@@ -6,14 +6,36 @@
 
 mod git;
 
+pub use git::GitIndexError;
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-pub use git::GitIndexError;
+use axum::http::StatusCode;
+use futures::future::BoxFuture;
+use thiserror::Error;
 
 use crate::model::cargo::IndexCrateMetadata;
 use crate::model::config::Configuration;
 use crate::utils::FaillibleFuture;
+use crate::utils::apierror::AsStatusCode;
+
+#[derive(Debug, Error)]
+pub enum IndexError {
+    #[error("package {package} is not in this registry")]
+    PackageNotInRegistry { package: String },
+
+    #[error(transparent)]
+    GitIndexError(#[from] GitIndexError),
+}
+impl AsStatusCode for IndexError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::PackageNotInRegistry { .. } => StatusCode::NOT_FOUND,
+            Self::GitIndexError(err) => err.status_code(),
+        }
+    }
+}
 
 /// Index implementations
 pub trait Index {
@@ -30,10 +52,10 @@ pub trait Index {
     fn publish_crate_version<'a>(&'a self, metadata: &'a IndexCrateMetadata) -> FaillibleFuture<'a, ()>;
 
     /// Removes a crate version from the index
-    fn remove_crate_version<'a>(&'a self, package: &'a str, version: &'a str) -> FaillibleFuture<'a, ()>;
+    fn remove_crate_version<'a>(&'a self, package: &'a str, version: &'a str) -> BoxFuture<'a, Result<(), IndexError>>;
 
     ///  Gets the data for a crate
-    fn get_crate_data<'a>(&'a self, package: &'a str) -> FaillibleFuture<'a, Vec<IndexCrateMetadata>>;
+    fn get_crate_data<'a>(&'a self, package: &'a str) -> BoxFuture<'a, Result<Vec<IndexCrateMetadata>, IndexError>>;
 }
 
 /// Gets path elements for a package in the file system

--- a/src/services/index/mod.rs
+++ b/src/services/index/mod.rs
@@ -9,10 +9,11 @@ mod git;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+pub use git::GitIndexError;
+
 use crate::model::cargo::IndexCrateMetadata;
 use crate::model::config::Configuration;
 use crate::utils::FaillibleFuture;
-use crate::utils::apierror::ApiError;
 
 /// Index implementations
 pub trait Index {
@@ -63,7 +64,7 @@ pub fn build_package_file_path(mut root: PathBuf, name: &str) -> PathBuf {
 }
 
 /// Gets the index service
-pub async fn get_service(config: &Configuration, expect_empty: bool) -> Result<Arc<dyn Index + Send + Sync>, ApiError> {
+pub async fn get_service(config: &Configuration, expect_empty: bool) -> Result<Arc<dyn Index + Send + Sync>, GitIndexError> {
     let index = git::GitIndex::new(config.get_index_git_config(), expect_empty).await?;
     Ok(Arc::new(index))
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,12 +6,13 @@
 
 use std::{io, path::PathBuf, sync::Arc};
 
+use index::GitIndexError;
 use thiserror::Error;
 
 use crate::model::config::{Configuration, WriteAuthConfigError};
 use crate::model::errors::MissingEnvVar;
 use crate::model::worker::WorkersManager;
-use crate::utils::apierror::{ApiError, AsStatusCode};
+use crate::utils::apierror::AsStatusCode;
 use crate::utils::db::RwSqlitePool;
 
 pub mod database;
@@ -49,7 +50,10 @@ pub trait ServiceProvider {
     fn get_storage(config: &Configuration) -> Arc<dyn storage::Storage + Send + Sync>;
 
     /// Gets the index service
-    async fn get_index(config: &Configuration, expect_empty: bool) -> Result<Arc<dyn index::Index + Send + Sync>, ApiError>;
+    async fn get_index(
+        config: &Configuration,
+        expect_empty: bool,
+    ) -> Result<Arc<dyn index::Index + Send + Sync>, GitIndexError>;
 
     /// Gets the rustsec service
     fn get_rustsec(config: &Configuration) -> Arc<dyn rustsec::RustSecChecker + Send + Sync>;
@@ -95,7 +99,10 @@ impl ServiceProvider for StandardServiceProvider {
     }
 
     /// Gets the index service
-    async fn get_index(config: &Configuration, expect_empty: bool) -> Result<Arc<dyn index::Index + Send + Sync>, ApiError> {
+    async fn get_index(
+        config: &Configuration,
+        expect_empty: bool,
+    ) -> Result<Arc<dyn index::Index + Send + Sync>, GitIndexError> {
         index::get_service(config, expect_empty).await
     }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,11 +4,14 @@
 
 //! Service implementations
 
-use std::sync::Arc;
+use std::{io, path::PathBuf, sync::Arc};
 
-use crate::model::config::Configuration;
+use thiserror::Error;
+
+use crate::model::config::{Configuration, WriteAuthConfigError};
+use crate::model::errors::MissingEnvVar;
 use crate::model::worker::WorkersManager;
-use crate::utils::apierror::ApiError;
+use crate::utils::apierror::{ApiError, AsStatusCode};
 use crate::utils::db::RwSqlitePool;
 
 pub mod database;
@@ -19,11 +22,28 @@ pub mod index;
 pub mod rustsec;
 pub mod storage;
 
+#[derive(Debug, Error)]
+pub enum ConfigurationError {
+    #[error("failed to get configuration")]
+    GetConfiguration(#[source] MissingEnvVar),
+
+    #[error("failed to write configuration")]
+    WriteConfiguration(#[source] WriteAuthConfigError),
+
+    #[error("failed to create temp dir '{path}'")]
+    CreateTempDir {
+        #[source]
+        source: io::Error,
+        path: PathBuf,
+    },
+}
+impl AsStatusCode for ConfigurationError {}
+
 /// Factory responsible for building services
 #[expect(async_fn_in_trait)]
 pub trait ServiceProvider {
     /// Gets the configuration
-    async fn get_configuration() -> Result<Configuration, ApiError>;
+    async fn get_configuration() -> Result<Configuration, ConfigurationError>;
 
     /// Gets the backing storage for the documentation
     fn get_storage(config: &Configuration) -> Arc<dyn storage::Storage + Send + Sync>;
@@ -58,9 +78,14 @@ pub struct StandardServiceProvider;
 
 impl ServiceProvider for StandardServiceProvider {
     /// Gets the configuration
-    async fn get_configuration() -> Result<Configuration, ApiError> {
-        let configuration = Configuration::from_env().await?;
-        configuration.write_auth_config().await?;
+    async fn get_configuration() -> Result<Configuration, ConfigurationError> {
+        let configuration = Configuration::from_env()
+            .await
+            .map_err(ConfigurationError::GetConfiguration)?;
+        configuration
+            .write_auth_config()
+            .await
+            .map_err(ConfigurationError::WriteConfiguration)?;
         Ok(configuration)
     }
 

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -19,7 +19,7 @@ use crate::model::deps::DepsAnalysis;
 use crate::model::docs::{DocGenEvent, DocGenJob, DocGenJobSpec, DocGenJobState, DocGenTrigger};
 use crate::model::osv::SimpleAdvisory;
 use crate::model::worker::WorkersManager;
-use crate::services::database::DbReadError;
+use crate::services::database::{DbReadError, DbWriteError};
 use crate::services::deps::DepsChecker;
 use crate::services::docs::DocsGenerator;
 use crate::services::emails::EmailSender;
@@ -137,7 +137,11 @@ impl DocsGenerator for MockService {
         resolved_default()
     }
 
-    fn queue<'a>(&'a self, spec: &'a DocGenJobSpec, trigger: &'a DocGenTrigger) -> FaillibleFuture<'a, DocGenJob> {
+    fn queue<'a>(
+        &'a self,
+        spec: &'a DocGenJobSpec,
+        trigger: &'a DocGenTrigger,
+    ) -> BoxFuture<'a, Result<DocGenJob, DbWriteError>> {
         Box::pin(async {
             Ok(DocGenJob {
                 id: -1,

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -21,12 +21,11 @@ use crate::model::worker::WorkersManager;
 use crate::services::deps::DepsChecker;
 use crate::services::docs::DocsGenerator;
 use crate::services::emails::EmailSender;
-use crate::services::index::Index;
+use crate::services::index::{GitIndexError, Index};
 use crate::services::rustsec::RustSecChecker;
 use crate::services::storage::Storage;
 use crate::services::{ConfigurationError, ServiceProvider};
 use crate::utils::FaillibleFuture;
-use crate::utils::apierror::ApiError;
 use crate::utils::db::RwSqlitePool;
 use crate::utils::token::generate_token;
 
@@ -56,7 +55,7 @@ impl ServiceProvider for MockService {
         Arc::new(Self)
     }
 
-    async fn get_index(_config: &Configuration, _expect_empty: bool) -> Result<Arc<dyn Index + Send + Sync>, ApiError> {
+    async fn get_index(_config: &Configuration, _expect_empty: bool) -> Result<Arc<dyn Index + Send + Sync>, GitIndexError> {
         Ok(Arc::new(Self))
     }
 

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::NaiveDateTime;
+use futures::future::BoxFuture;
 use semver::Version;
 use tokio::sync::mpsc::Sender;
 
@@ -21,7 +22,7 @@ use crate::model::worker::WorkersManager;
 use crate::services::deps::DepsChecker;
 use crate::services::docs::DocsGenerator;
 use crate::services::emails::EmailSender;
-use crate::services::index::{GitIndexError, Index};
+use crate::services::index::{GitIndexError, Index, IndexError};
 use crate::services::rustsec::RustSecChecker;
 use crate::services::storage::Storage;
 use crate::services::{ConfigurationError, ServiceProvider};
@@ -32,7 +33,7 @@ use crate::utils::token::generate_token;
 /// A mocking service
 pub struct MockService;
 
-fn resolved_default<T: Default + Send>() -> FaillibleFuture<'static, T> {
+fn resolved_default<T: Default + Send, E>() -> BoxFuture<'static, Result<T, E>> {
     Box::pin(async { Ok(T::default()) })
 }
 
@@ -102,11 +103,11 @@ impl Index for MockService {
         resolved_default()
     }
 
-    fn remove_crate_version<'a>(&'a self, _package: &'a str, _version: &'a str) -> FaillibleFuture<'a, ()> {
+    fn remove_crate_version<'a>(&'a self, _package: &'a str, _version: &'a str) -> BoxFuture<'a, Result<(), IndexError>> {
         resolved_default()
     }
 
-    fn get_crate_data<'a>(&'a self, _package: &'a str) -> FaillibleFuture<'a, Vec<IndexCrateMetadata>> {
+    fn get_crate_data<'a>(&'a self, _package: &'a str) -> BoxFuture<'a, Result<Vec<IndexCrateMetadata>, IndexError>> {
         resolved_default()
     }
 }

--- a/src/tests/mocks.rs
+++ b/src/tests/mocks.rs
@@ -19,6 +19,7 @@ use crate::model::deps::DepsAnalysis;
 use crate::model::docs::{DocGenEvent, DocGenJob, DocGenJobSpec, DocGenJobState, DocGenTrigger};
 use crate::model::osv::SimpleAdvisory;
 use crate::model::worker::WorkersManager;
+use crate::services::database::DbReadError;
 use crate::services::deps::DepsChecker;
 use crate::services::docs::DocsGenerator;
 use crate::services::emails::EmailSender;
@@ -128,7 +129,7 @@ impl DepsChecker for MockService {
 }
 
 impl DocsGenerator for MockService {
-    fn get_jobs(&self) -> FaillibleFuture<'_, Vec<DocGenJob>> {
+    fn get_jobs(&self) -> BoxFuture<'_, Result<Vec<DocGenJob>, DbReadError>> {
         resolved_default()
     }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -10,10 +10,10 @@ use std::sync::Arc;
 use chrono::Local;
 use tokio::runtime::Builder;
 
-use crate::application::Application;
+use crate::application::{Application, LaunchError};
 use crate::model::auth::ROLE_ADMIN;
 use crate::services::ServiceProvider;
-use crate::utils::apierror::ApiError;
+use crate::utils::apierror::{ApiError, AsStatusCode};
 use crate::utils::axum::auth::{AuthData, Token};
 use crate::utils::token::{generate_token, hash_token};
 
@@ -22,6 +22,9 @@ pub mod security;
 
 pub const ADMIN_UID: i64 = 1;
 pub const ADMIN_NAME: &str = "admin";
+
+// used in `async_test`
+impl AsStatusCode for LaunchError {}
 
 /// Wrapper for async tests
 pub fn async_test<F, FUT>(payload: F) -> Result<(), ApiError>

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -72,8 +72,7 @@ pub async fn setup_create_user_base(
                 .bind(is_active)
                 .bind(roles)
                 .execute(&mut *app.database.transaction.borrow().await)
-                .await?;
-            Ok::<(), ApiError>(())
+                .await
         })
         .await?;
     Ok(())
@@ -97,8 +96,7 @@ pub async fn setup_create_token(
             .bind(Local::now().naive_local())
             .bind(can_write)
             .bind(can_admin)
-            .execute(&mut *app.database.transaction.borrow().await).await?;
-            Ok::<(), ApiError>(())
+            .execute(&mut *app.database.transaction.borrow().await).await
         }
     }).await?;
     Ok(token_secret)

--- a/src/utils/apierror.rs
+++ b/src/utils/apierror.rs
@@ -106,7 +106,7 @@ pub fn error_not_found() -> ApiError {
 #[must_use]
 pub fn error_conflict() -> ApiError {
     ApiError::new(
-        408,
+        409, //StatusCode::CONFLICT
         "The request could not be processed because of conflict in the current state of the resource.",
         None,
     )

--- a/src/utils/apierror.rs
+++ b/src/utils/apierror.rs
@@ -19,7 +19,7 @@ pub struct ApiError {
     /// Optional details for the error
     pub details: Option<String>,
     /// The backtrace when the error was produced
-    #[serde(skip_serializing, skip_deserializing)]
+    #[serde(skip)]
     pub backtrace: Option<Backtrace>,
 }
 

--- a/src/utils/apierror.rs
+++ b/src/utils/apierror.rs
@@ -7,13 +7,15 @@
 use std::backtrace::Backtrace;
 use std::fmt::{Display, Formatter};
 
+use axum::http::StatusCode;
 use serde_derive::{Deserialize, Serialize};
 
 /// Describes an API error
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApiError {
-    /// The associated HTTP error code
-    pub http: u16,
+    /// The associated HTTP status code
+    #[serde(with = "http_serde::status_code")]
+    pub http: StatusCode,
     /// A custom error message
     pub message: String,
     /// Optional details for the error
@@ -27,7 +29,7 @@ impl ApiError {
     /// Creates a new error
     #[expect(clippy::needless_pass_by_value)]
     #[must_use]
-    pub fn new<M: ToString>(http: u16, message: M, details: Option<String>) -> Self {
+    pub fn new<M: ToString>(http: StatusCode, message: M, details: Option<String>) -> Self {
         Self {
             http,
             message: message.to_string(),
@@ -60,7 +62,7 @@ where
     E: std::error::Error,
 {
     fn from(err: E) -> Self {
-        Self::new(500, "The operation failed in the backend.", Some(err.to_string()))
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, "The operation failed in the backend.", Some(err.to_string()))
     }
 }
 
@@ -75,38 +77,46 @@ pub fn specialize(original: ApiError, details: String) -> ApiError {
 /// Error when the operation failed in the backend
 #[must_use]
 pub fn error_backend_failure() -> ApiError {
-    ApiError::new(500, "The operation failed in the backend.", None)
+    ApiError::new(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "The operation failed in the backend.",
+        None,
+    )
 }
 
 /// Error when the operation failed due to invalid input
 #[must_use]
 pub fn error_invalid_request() -> ApiError {
-    ApiError::new(400, "The request could not be understood by the server.", None)
+    ApiError::new(
+        StatusCode::BAD_REQUEST,
+        "The request could not be understood by the server.",
+        None,
+    )
 }
 
 /// Error when the user is not authorized (not logged in)
 #[must_use]
 pub fn error_unauthorized() -> ApiError {
-    ApiError::new(401, "User is not authenticated.", None)
+    ApiError::new(StatusCode::UNAUTHORIZED, "User is not authenticated.", None)
 }
 
 /// Error when the requested action is forbidden to the (otherwise authenticated) user
 #[must_use]
 pub fn error_forbidden() -> ApiError {
-    ApiError::new(403, "This action is forbidden to the user.", None)
+    ApiError::new(StatusCode::FORBIDDEN, "This action is forbidden to the user.", None)
 }
 
 /// Error when the requested user cannot be found
 #[must_use]
 pub fn error_not_found() -> ApiError {
-    ApiError::new(404, "The requested resource cannot be found.", None)
+    ApiError::new(StatusCode::NOT_FOUND, "The requested resource cannot be found.", None)
 }
 
 /// Error when the request has a conflicts
 #[must_use]
 pub fn error_conflict() -> ApiError {
     ApiError::new(
-        409, //StatusCode::CONFLICT
+        StatusCode::CONFLICT,
         "The request could not be processed because of conflict in the current state of the resource.",
         None,
     )

--- a/src/utils/apierror.rs
+++ b/src/utils/apierror.rs
@@ -5,7 +5,7 @@
 //! Definition of the error type for API requests
 
 use std::backtrace::Backtrace;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Display, Formatter, Write};
 
 use axum::http::StatusCode;
 use serde_derive::{Deserialize, Serialize};
@@ -150,4 +150,13 @@ pub fn error_conflict() -> ApiError {
         "The request could not be processed because of conflict in the current state of the resource.",
         None,
     )
+}
+
+#[must_use]
+pub(crate) fn anyhow_err_stack_to_string(err: &anyhow::Error) -> String {
+    let chain = err.chain();
+    chain.enumerate().fold(String::new(), |mut val, (idx, err)| {
+        let _ = writeln!(&mut val, "*[{idx}]: {err}");
+        val
+    })
 }

--- a/src/utils/axum/auth.rs
+++ b/src/utils/axum/auth.rs
@@ -17,7 +17,6 @@ use cookie::{Cookie, CookieJar, Expiration, Key, SameSite};
 
 use super::extractors::Cookies;
 use crate::model::auth::Authentication;
-use crate::utils::apierror::ApiError;
 
 /// An authentication token
 #[derive(Debug, Clone)]
@@ -196,13 +195,12 @@ impl AuthData {
     /// # Errors
     ///
     /// Propagates the error from the `check_token` callback.
-    pub fn try_authenticate_cookie(&self) -> Result<Option<Authentication>, ApiError> {
+    pub fn try_authenticate_cookie(&self) -> Result<Option<Authentication>, serde_json::Error> {
         // try the cookie
-        Ok(self
-            .cookie_jar
+        self.cookie_jar
             .private(&self.cookie_key)
             .get(&self.cookie_id_name)
             .map(|cookie| serde_json::from_str(cookie.value()))
-            .transpose()?)
+            .transpose()
     }
 }

--- a/src/utils/axum/mod.rs
+++ b/src/utils/axum/mod.rs
@@ -36,17 +36,8 @@ pub fn response_error(error: ApiError) -> (StatusCode, Json<ApiError>) {
 }
 
 /// Produces an OK response
-///
-/// # Panics
-///
-/// Panic when the HTTP code is not a correct status code
-pub fn response_ok_http<T>(http: u16, data: T) -> (StatusCode, Json<T>) {
-    (StatusCode::from_u16(http).unwrap(), Json(data))
-}
-
-/// Produces an OK response
-pub fn response_ok<T>(data: T) -> (StatusCode, Json<T>) {
-    response_ok_http(200, data)
+pub const fn response_ok<T>(data: T) -> (StatusCode, Json<T>) {
+    (StatusCode::OK, Json(data))
 }
 
 /// Maps a service result to a web api result

--- a/src/utils/axum/mod.rs
+++ b/src/utils/axum/mod.rs
@@ -19,19 +19,15 @@ use crate::utils::apierror::ApiError;
 pub type ApiResult<T> = Result<(StatusCode, Json<T>), (StatusCode, Json<ApiError>)>;
 
 /// Produces an error response
-///
-/// # Panics
-///
-/// Panic when the HTTP code is not a correct status code
-pub fn response_error_http(http: u16, error: ApiError) -> (StatusCode, Json<ApiError>) {
-    if http == 500 {
+pub fn response_error_http(http: StatusCode, error: ApiError) -> (StatusCode, Json<ApiError>) {
+    if http == StatusCode::INTERNAL_SERVER_ERROR {
         // log internal errors
         error!("{error}");
         if let Some(backtrace) = &error.backtrace {
             error!("{backtrace}");
         }
     }
-    (StatusCode::from_u16(http).unwrap(), Json(error))
+    (http, Json(error))
 }
 
 /// Produces an error response

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -18,6 +18,7 @@ use sqlx::{Pool, Sqlite, SqliteConnection, Transaction};
 use thiserror::Error;
 
 use super::apierror::ApiError;
+use crate::utils::apierror::AsStatusCode;
 use crate::utils::shared::{ResourceLock, SharedResource, StillSharedError};
 
 /// Maximum number of concurrent READ connections
@@ -216,3 +217,4 @@ pub enum MigrationError {
     #[error("the transaction was still shared when a it terminated")]
     SharedTransaction(StillSharedError),
 }
+impl AsStatusCode for MigrationError {}

--- a/src/utils/db.rs
+++ b/src/utils/db.rs
@@ -15,6 +15,7 @@ use log::error;
 use serde_derive::{Deserialize, Serialize};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use sqlx::{Pool, Sqlite, SqliteConnection, Transaction};
+use thiserror::Error;
 
 use super::apierror::ApiError;
 use crate::utils::shared::{ResourceLock, SharedResource, StillSharedError};
@@ -203,50 +204,15 @@ impl Ord for VersionNumber {
 }
 
 /// An error during a migration
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum MigrationError {
     /// Error when the version number is invalid
-    InvalidVersion(InvalidVersionNumber),
+    #[error(transparent)]
+    InvalidVersion(#[from] InvalidVersionNumber),
     /// An SQL error
-    Sql(sqlx::Error),
+    #[error(transparent)]
+    Sql(#[from] sqlx::Error),
     /// The transaction was still shared when a migration is terminated
+    #[error("the transaction was still shared when a it terminated")]
     SharedTransaction(StillSharedError),
-}
-
-impl Display for MigrationError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InvalidVersion(inner) => inner.fmt(f),
-            Self::Sql(inner) => inner.fmt(f),
-            Self::SharedTransaction(_) => write!(f, "the transaction was still shared when a it terminated"),
-        }
-    }
-}
-
-impl std::error::Error for MigrationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::InvalidVersion(inner) => Some(inner),
-            Self::Sql(inner) => Some(inner),
-            Self::SharedTransaction(inner) => Some(inner),
-        }
-    }
-}
-
-impl From<InvalidVersionNumber> for MigrationError {
-    fn from(err: InvalidVersionNumber) -> Self {
-        Self::InvalidVersion(err)
-    }
-}
-
-impl From<sqlx::Error> for MigrationError {
-    fn from(err: sqlx::Error) -> Self {
-        Self::Sql(err)
-    }
-}
-
-impl From<StillSharedError> for MigrationError {
-    fn from(err: StillSharedError) -> Self {
-        Self::SharedTransaction(err)
-    }
 }


### PR DESCRIPTION
`thiserror` allow to easly get a error stack, instead of only the leaf error.
`anyhow` allow to return error and print the error stack

This change the behavior of app from `crash` to `error return`, this can impact interaction with container or other service management.
But it keep the backtrace capability when error happen.
:question: This should be consider and validated. 

:construction_worker: If the idea is validated, need some work to improve config rework and manage `write_auth_config_git` or `Application::launch` part.

## Example : if missing `REGISTRY_OAUTH_LOGIN_URI` en var

### before
```
thread 'main' panicked at src/main.rs:196:86:
called `Result::unwrap()` on an `Err` value: ApiError { http: 500, message: "The operation failed in the backend.", details: Some("missing expected env var REGISTRY_OAUTH_LOGIN_URI"), backtrace: Some(<disabled>) }
```

### after use `thiserror`
```
thread 'main' panicked at src/main.rs:196:86:
called `Result::unwrap()` on an `Err` value: GetConfiguration(MissingEnvVar { original: NotPresent, var_name: "REGISTRY_OAUTH_LOGIN_URI" })
```

### after use `anyhow` too
```
Error: Standard Service get configuration.

Caused by:
    0: Failed to get configuration
    1: missing expected env var REGISTRY_OAUTH_LOGIN_URI
    2: environment variable not found
```