### PR TITLE
Remove duplicate `can` in set_crate_can_can_remove

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -789,16 +789,11 @@ impl Application {
     }
 
     /// Sets whether a crate can have versions completely removed
-    pub async fn set_crate_can_can_remove(
-        &self,
-        auth_data: &AuthData,
-        package: &str,
-        can_remove: bool,
-    ) -> Result<(), ApiError> {
-        self.db_transaction_write("set_crate_can_can_remove", |app| async move {
+    pub async fn set_crate_can_remove(&self, auth_data: &AuthData, package: &str, can_remove: bool) -> Result<(), ApiError> {
+        self.db_transaction_write("set_crate_can_remove", |app| async move {
             let authentication = app.authenticate(auth_data).await?;
             app.check_can_manage_crate(&authentication, package).await?;
-            app.database.set_crate_can_can_remove(package, can_remove).await
+            app.database.set_crate_can_remove(package, can_remove).await
         })
         .await
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ async fn main_serve_app(application: Arc<Application>, cookie_key: Key) -> Resul
                             patch(routes::api_v1_set_crate_required_capabilities),
                         )
                         .route("/{package}/deprecated", patch(routes::api_v1_set_crate_deprecation))
-                        .route("/{package}/canremove", patch(routes::api_v1_set_crate_can_can_remove)),
+                        .route("/{package}/canremove", patch(routes::api_v1_set_crate_can_remove)),
                 ),
         )
         // fall back to serving the index

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -941,18 +941,13 @@ pub async fn api_v1_set_crate_deprecation(
 }
 
 /// Sets whether a crate can have versions completely removed
-pub async fn api_v1_set_crate_can_can_remove(
+pub async fn api_v1_set_crate_can_remove(
     auth_data: AuthData,
     State(state): State<Arc<AxumState>>,
     Path(PathInfoCrate { package }): Path<PathInfoCrate>,
     input: Json<bool>,
 ) -> ApiResult<()> {
-    response(
-        state
-            .application
-            .set_crate_can_can_remove(&auth_data, &package, input.0)
-            .await,
-    )
+    response(state.application.set_crate_can_remove(&auth_data, &package, input.0).await)
 }
 
 pub async fn index_serve_inner(

--- a/src/services/database/packages.rs
+++ b/src/services/database/packages.rs
@@ -865,7 +865,7 @@ impl Database {
     }
 
     /// Sets whether a crate can have versions completely removed
-    pub async fn set_crate_can_can_remove(&self, package: &str, can_remove: bool) -> Result<(), ApiError> {
+    pub async fn set_crate_can_remove(&self, package: &str, can_remove: bool) -> Result<(), ApiError> {
         sqlx::query!("UPDATE Package SET canRemove = $2 WHERE name = $1", package, can_remove)
             .execute(&mut *self.transaction.borrow().await)
             .await?;


### PR DESCRIPTION
The double can in `set_crate_can_can_remove` doesn't seem to make sense