### PR TITLE
ci: move typos check in it's own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Check fmt
         run: cargo fmt --check
-      - name: Check spelling
-        uses: crate-ci/typos@master
       - name: Lint
         run: cargo clippy --locked
       - name: Run tests
         run: cargo test --locked
+
+  typos:
+    name: Check spelling with typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@master
 
   taplo:
     name: Toml format check


### PR DESCRIPTION
This allows you to better visualize in the ui whether there are typos or not.
And it more consistent with taplo and machete job