### PR TITLE
Reworked docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     image: cenotelie/cratery:latest
     restart: unless-stopped
     ports:
-      - "80:80"
+      - "127.0.0.1:8080:80"
     volumes:
-      - ./data:/data
+      - vol-data:/data
     environment:
       RUST_BACKTRACE: 1
       # REGISTRY_LOG_LEVEL: INFO
@@ -57,3 +57,6 @@ services:
       # REGISTRY_SELF_LOCAL_NAME: localhost
       # REGISTRY_NODE_ROLE: standalone
       # REGISTRY_NODE_WORKER_TOKEN: super secret token
+
+volumes:
+  vol-data:


### PR DESCRIPTION
Uses integrated volumes rather than bind mount to local directory. Fixes #64 .

The resulting image is also smaller:
```
omikron@archlinux ~/g/cratery (main)> docker image ls | grep cratery
cenotelie/cratery                              latest                 e7e494060dd4   15 minutes ago      1.67GB
cenotelie/cratery                              v1.13.0                417f5d45b95d   8 weeks ago         2.97GB
```