### PR TITLE
CI: add sheduled audit and dependencies check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
     # Check for updates every Monday
     schedule:
       interval: "weekly"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,11 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
+
+  # Enable version updates for rust
+  - package-ecosystem: "rust-toolchain"
+    # Look for `Cargo.lock` files in the `root` directory
+    directory: "/"
+    # Check the cargo registry for updates once a week
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: Scheduled Audit
+
+on:
+  schedule:
+    # daily at 8 AM
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  rust-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: Scheduled Audit
+
+on:
+  schedule:
+    # daily at 8 AM
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  rust-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           log-level: warn
@@ -30,14 +30,14 @@ jobs:
     name: Check spelling with typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: crate-ci/typos@master
 
   taplo:
     name: Toml format check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: gwen-lg/taplo-action@v1
         with:
           format: true
@@ -47,6 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Machete
         uses: bnjbvr/cargo-machete@main


### PR DESCRIPTION
- run rust code audit with `EmbarkStudios/cargo-deny-action@v2`
- check dependencies of `github-actions`